### PR TITLE
 Expand README with all links to previous calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,35 @@
 
  №  | Date                             | Notes          | Recording            |
 --- | -------------------------------- | -------------- | -------------------- |
- 35 | Fri, March 23, 2018 14:00 UTC    | [agenda](https://github.com/ethereum/pm/issues/33) | |
- 34 | Fri, February 23, 2018 14:00 UTC | [notes](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2034.md) [agenda](https://github.com/ethereum/pm/issues/32) [reddit](https://www.reddit.com/r/ethereum/comments/7zpxe3/notes_from_ethereum_core_devs_meeting_34_22318/) | [video](https://www.youtube.com/watch?v=GhUtruRZOlo) |
+ 35 | Fri, March 23, 2018 14:00 UTC    | [agenda](https://github.com/ethereum/pm/issues/33) | TBA |
+ 34 | Fri, February 23, 2018 14:00 UTC | [agenda](https://github.com/ethereum/pm/issues/32) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2034.md) \| [reddit](https://www.reddit.com/r/ethereum/comments/7zpxe3/notes_from_ethereum_core_devs_meeting_34_22318/) | [video](https://youtu.be/GhUtruRZOlo) |
+ 33 | Fri, February 9, 2018 14:00 UTC  | [agenda](https://github.com/ethereum/pm/issues/31) | [video](https://youtu.be/wPBzs2NBnsA) |
+ 32 | Fri, January 26, 2018 14:00 UTC  | [agenda](https://github.com/ethereum/pm/issues/30) | [video](https://youtu.be/ZtPy9r0jthI) |
+ 31 | Fri, December 1, 2018 14:00 UTC  | [agenda](https://github.com/ethereum/pm/issues/29) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2031.md) \| [reddit](https://www.reddit.com/r/ethereum/comments/7pu8hr/live_1400_utc_ethereum_core_devs_meeting_31_011218/) | [video](https://youtu.be/biNCOCQdjQ0) |
+ 30 | Fri, December 15, 2017 14:00 UTC | [agenda](https://github.com/ethereum/pm/issues/28) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2030.md) | [video](https://youtu.be/naPA7tjrgsk) |
+ 29 | Fri, December 1, 2017 14:00 UTC  | [agenda](https://github.com/ethereum/pm/issues/27) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2029.md) | [video](https://youtu.be/1GulA7iA-O0) |
+ 28 | Fri, November 17, 2017 14:00 UTC | [agenda](https://github.com/ethereum/pm/issues/26) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2028.md) | [video](https://youtu.be/8S-MEGYq_CI) |
+ 27 | Fri, October 20, 2017  14:00 UTC | [agenda](https://github.com/ethereum/pm/issues/25) | [video](https://youtu.be/ZN-AtGgtmtA) |
+ 26 | Fri, October 6, 2017 14:00 UTC   | [agenda](https://github.com/ethereum/pm/issues/24) | [video](https://youtu.be/AC2vL7hxu4c) |
+ 25 | Fri, September 22, 2017 14:00 UTC| [agenda](https://github.com/ethereum/pm/issues/23) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2025.md) | [video](https://youtu.be/gxtftZB7_jA) |
+ 24 | Fri, September 8, 2017 14:00 UTC | [agenda](https://github.com/ethereum/pm/issues/22) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2024.md) | [video](https://youtu.be/_5Tp_U1jBww) |
+ 23 | Fri, August 25, 2017 14:00 UTC   | [agenda](https://github.com/ethereum/pm/issues/21) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2023.md) | [video](https://youtu.be/PQjeAZyL2_w) |
+ 22 | Fri, August 11, 2017 14:00 UTC   | [agenda](https://github.com/ethereum/pm/issues/20) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2022.md) | [video](https://youtu.be/R_943As7WMg) |
+ 21 | Fri, July 28, 2017 14:00 UTC     | [agenda](https://github.com/ethereum/pm/issues/19) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2021.md) | [video](https://youtu.be/GK4a6Y5wnFY) |
+ 20 | Fri, July 14, 2017 14:00 UTC     | [agenda](https://github.com/ethereum/pm/issues/18) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2020.md) | [video](https://youtu.be/hRQg_lHEKl4) |
+ 19 | Fri, June 30, 2017 14:00 UTC     | [agenda](https://github.com/ethereum/pm/issues/17) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2019.md) | [video](https://youtu.be/wLaI7680I4w) |
+ 18 | Fri, June 16, 2017 14:00 UTC     | [agenda](https://github.com/ethereum/pm/issues/16) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2018.md) | [video](https://youtu.be/8jWhPylWros) |
+ 17 | Fri, June 3, 2017 14:00 UTC      | [agenda](https://github.com/ethereum/pm/issues/15) | [video](https://youtu.be/E77sdcZZH0s) |
+ 16 | Fri, May 19, 2017 14:00 UTC      | [agenda](https://github.com/ethereum/pm/issues/14) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2016.md) | [video](https://youtu.be/brhanl8T2UY) |
+ 15 | Fri, May 5, 2017 14:00 UTC       | [agenda](https://github.com/ethereum/pm/issues/13) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2015.md) | not recorded |
+ 14 | Fri, April 21, 2017 14:00 UTC    | [agenda](https://github.com/ethereum/pm/issues/12) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2014.md) | [video](https://youtu.be/PGi0vBxDPHY) |
+ 13 | Fri, April 7, 2017 14:00 UTC     | [agenda](https://github.com/ethereum/pm/issues/8) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2013.md) | [video](https://youtu.be/aGeGvZ5uS8s) |
+ 12 | Fri, March 17, 2017 14:00 UTC    | [agenda](https://github.com/ethereum/pm/issues/7) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2012.md) | [video](https://youtu.be/g2gsYRlThD4) |
+ 11 | Fri, March 3, 2017 14:00 UTC     | [agenda](https://github.com/ethereum/pm/issues/6) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2011.md) | [video](https://youtu.be/EiXwg9vjGdY) |
+ 10 | Fri, February 10, 2017 14:00 UTC| [agenda](https://github.com/ethereum/pm/issues/5) \| [notes](All%20Core%20Devs%20Meetings/Meeting%2010.md) | [video](https://youtu.be/huYl7eOlKJE) |
+  9 | Wed, January 25, 2017 14:00 UTC  | [agenda](https://github.com/ethereum/pm/issues/3) \| [notes](All%20Core%20Devs%20Meetings/Meeting%208.md) | [video](https://youtu.be/ex51Gb3SVqo) |
+  8 | Fri, October 28, 2016 13:00 UTC  | [agenda](https://github.com/ethereum/pm/issues/1) \| [notes](All%20Core%20Devs%20Meetings/Meeting%209.md) | not recorded |
+
+
+
+


### PR DESCRIPTION
Shouldn't be too hard for people to find the notes in this repository, but having such a half-updated README isn't really helpful either. Some notes and videos are not available. 