### PR TITLE
Add GitPOAP Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ethereum Project Management Repository
 
+[![gitpoap badge](https://public-api.gitpoap.io/v1/repo/ethereum/pm/badge)](https://www.gitpoap.io/gh/ethereum/pm)
+
 This repository is used for project management for various initiatives affecting the Ethereum protocol. The main use of this repository is for the All Core Devs meeting, but it is also used for [Ethereum 1.x](/Archive/ETH-1X), [Merge](/Merge) and [Fee Market](/Archive/Fee-Market) meetings.
 
 ## All Core Devs Meetings


### PR DESCRIPTION
Hey Tim, this PR adds a [GitPOAP Badge](https://docs.gitpoap.io/api#get-v1repoownernamebadge) to the README that displays the number of minted GitPOAPs for this repository by contributors to this repo.

You can see an example of this in [our Documentation repository](https://github.com/gitpoap/gitpoap-docs#gitpoap-docs).

This should help would-be contributors as well as existing contributors find out that they will/have received GitPOAPs for their contributions.