### PR TITLE
fix: typos in documentation files

### DIFF
--- a/Network-Upgrade-Archive/Dencun/4844-readiness-checklist.md
+++ b/Network-Upgrade-Archive/Dencun/4844-readiness-checklist.md
@@ -14,7 +14,7 @@ This document is meant to capture various tasks that need to be completed before
 
 #### Execution Layer 
 
-### Implementation Progresss
+### Implementation Progress
 
 Implementation status of Included EIPs across participating clients.
 

--- a/Network-Upgrade-Archive/Dencun/dencun-pm.md
+++ b/Network-Upgrade-Archive/Dencun/dencun-pm.md
@@ -23,4 +23,4 @@ The document outlines the specifications for Ethereum's Dencun devnet. The netwo
 
 # 4844 Readinesss Checklist
 
-Early in Dencun devlopment, the [`4844-readiness-checklist`](4844-readiness-checklist.md) was created to track implementation progress & open issues. Once EIP-4844 was included in the Dencun network upgrade, it was replaced by the various dencun devnet spec documents. 
+Early in Dencun development, the [`4844-readiness-checklist`](4844-readiness-checklist.md) was created to track implementation progress & open issues. Once EIP-4844 was included in the Dencun network upgrade, it was replaced by the various dencun devnet spec documents. 

--- a/Network-Upgrade-Archive/Dencun/devnet-10.md
+++ b/Network-Upgrade-Archive/Dencun/devnet-10.md
@@ -25,7 +25,7 @@
 ## [Docker images](https://github.com/ethpandaops/dencun-testnet/blob/master/ansible/inventories/devnet-10/group_vars/all/images.yaml) for devnet 10
 
 ### Open issues
-[Prysm-13097](https://github.com/prysmaticlabs/prysm/issues/13097) - triggered by the accidential non finality event at epoch 32-35 - Closed
+[Prysm-13097](https://github.com/prysmaticlabs/prysm/issues/13097) - triggered by the accidental non finality event at epoch 32-35 - Closed
 [Teku-7626](https://github.com/Consensys/teku/issues/7626) - triggered by mass deposits - Closed
 MEV-Boost - timestamp too early issue (no open issue yet)
 MEV-Relay - Error: BLOCK_ERROR_INVALID_STATE_ROOT (no open issue yet)

--- a/Network-Upgrade-Archive/Merge/Meeting 05.md
+++ b/Network-Upgrade-Archive/Merge/Meeting 05.md
@@ -6,7 +6,7 @@
 ### Moderator: Mikhail Kalinin
 ### Notes: Shane Lightowler
 
-# Inmplementation updates
+# Implementation updates
 
 **Mikhail Kalinin**
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

Corrected `Progresss` → `Progress`
Corrected `devlopment` → `development`
Corrected `accidential` → `accidental`
Corrected `Inmplementation` → `Implementation`
