### PR TITLE
docs: fix minor typos in R&D and Testing sections

### DIFF
--- a/Fusaka/peerdas-readiness.md
+++ b/Fusaka/peerdas-readiness.md
@@ -53,7 +53,7 @@ This document outlines various tasks to work through to make PeerDAS ready for M
 ## Testing
 
 * [ ] Tooling updates
-  * [ ] `spamoor` needs updating to use the new tx format, potentially we need a way to make sure clients are indeed adhering this change
+  * [ ] `spamoor` needs updating to use the new tx format, potentially we need a way to make sure clients are indeed adhering to this change
 * [ ] [EELS](https://github.com/ethereum/execution-specs) Implementation
 * [ ] [EEST](https://github.com/ethereum/execution-spec-tests) Tests
 * [ ] Hive
@@ -69,7 +69,7 @@ This document outlines various tasks to work through to make PeerDAS ready for M
  
 ## R&D
 
-* [ ] Anaylsis of new blob count impact on bandwidth, hardware requirements once clients are feature complete (`peerdas-devnet-6`)
+* [ ] Analysis of new blob count impact on bandwidth, hardware requirements once clients are feature complete (`peerdas-devnet-6`)
 * [ ] Nice to have: [BPO only forks](https://ethereum-magicians.org/t/blob-parameter-only-bpo-forks/22623)
 * [ ] EL: Potential optimisation of `getBlobs` endpoint?
 * [ ] Document impact to node operators (prior post with 16 blobs [here](https://blog.sigmaprime.io/peerdas-distributed-blob-building.html#impact-on-node-operators))


### PR DESCRIPTION
Spotted and fixed two typos in the documentation:  

- **"Anaylsis" → "Analysis"** in the **R&D** section.  
- **"adhering this change" → "adhering to this change"** in the **Testing → Tooling updates** section.  

Thanks!