### PR TITLE
Eth simulate update (Feb 24 - Mar 17)

### DIFF
--- a/Breakout-Room-Meetings/ETH-Simulate/EthSimulate-pm.md
+++ b/Breakout-Room-Meetings/ETH-Simulate/EthSimulate-pm.md
@@ -7,6 +7,10 @@ This meeting is for the discussion of eth_simulateV1 implementation and potentia
 
 | # | Date | Agenda | Recording | Notes |
 | -- | --| -- | -- | -- |
+| 42 |March 17, 2025| [Agenda](https://github.com/ethereum/pm/issues/1387#issue-2925132165) | [Recording](https://youtu.be/Lcd7_CDKV7w) | [Notes](https://github.com/ethereum/pm/issues/1387#issuecomment-2736180915) |
+| 41 |March 10, 2025| [Agenda](https://github.com/ethereum/pm/issues/1352#issue-2898141594) | [Recording](https://youtu.be/aTvdYmrZwi0) | [Notes](https://github.com/ethereum/pm/issues/1352#issuecomment-2715742739) |
+| 40 |March 03, 2025| [Agenda](https://github.com/ethereum/pm/issues/1330#issue-2882886091) | [Recording](https://youtu.be/uQeN-oem-r0) | [Notes](https://github.com/ethereum/pm/issues/1330#issuecomment-2694856028) |
+| 39 |February 24, 2025| [Agenda](https://github.com/ethereum/pm/issues/1302#issue-2859240773) | [Recording](https://youtu.be/4hvX2CyQW8g) | [Notes](https://github.com/ethereum/pm/issues/1302#issuecomment-2683358508) |
 | 38 |February 17, 2025| [Agenda](https://github.com/ethereum/pm/issues/1293) | [Recording](https://www.youtube.com/watch?v=Yer5Rue4M5s) | [Notes](https://github.com/ethereum/pm/issues/1293#issuecomment-2664759485) |
 | 37 |February 10, 2025| [Agenda](https://github.com/ethereum/pm/issues/1278) | [Recording](https://youtu.be/YgU7S01PUZc?si=_Vj0Aa8YKnYXJq1C) | [Notes]([./Meeting%2063.md](https://github.com/ethereum/pm/issues/1278#issuecomment-2650875573)) |
 | 36 |February 03, 2025| [Agenda](https://github.com/ethereum/pm/issues/1273) | [Recording](https://youtu.be/i2JBDF_MBVU?si=zBjWUwY4F_WfLzrw) | [Notes]([./Meeting%2063.md](https://github.com/ethereum/pm/issues/1273#issuecomment-2631171565)) |

--- a/Breakout-Room-Meetings/ETH-Simulate/Meeting 39.md
+++ b/Breakout-Room-Meetings/ETH-Simulate/Meeting 39.md
@@ -3,7 +3,7 @@ Note: This file is copied from [here](https://github.com/ethereum/pm/issues/1302
 
 ### Meeting Info
 
-- Agenda: [ethereum#1293](https://github.com/ethereum/pm/issues/1302#issue-2859240773)
+- Agenda: [ethereum#1302](https://github.com/ethereum/pm/issues/1302#issue-2859240773)
 - Date & Time: February 24, 2025, 12:00 UTC
 - Recording: [here](https://youtu.be/4hvX2CyQW8g)
 ## Notes

--- a/Breakout-Room-Meetings/ETH-Simulate/Meeting 39.md
+++ b/Breakout-Room-Meetings/ETH-Simulate/Meeting 39.md
@@ -1,0 +1,1 @@
+# Eth_Simulate Meeting Meeting 39

--- a/Breakout-Room-Meetings/ETH-Simulate/Meeting 39.md
+++ b/Breakout-Room-Meetings/ETH-Simulate/Meeting 39.md
@@ -1,1 +1,65 @@
 # Eth_Simulate Meeting Meeting 39
+Note: This file is copied from [here](https://github.com/ethereum/pm/issues/1302)
+
+### Meeting Info
+
+- Agenda: [ethereum#1293](https://github.com/ethereum/pm/issues/1302#issue-2859240773)
+- Date & Time: February 24, 2025, 12:00 UTC
+- Recording: [here](https://youtu.be/4hvX2CyQW8g)
+## Notes
+## Eth_Simulate Implementers Call Summary  
+
+## Overview  
+The meeting focused on resolving test case issues, progressing the tracing PR, and finalizing the approach for gas estimation. The team emphasized aligning implementations with user needs and gathering stakeholder feedback to ensure a robust and user-friendly solution.  
+
+## Key Discussion Points  
+
+### Test Case Updates  
+- **Killari** reported that several test cases related to Geth and other areas have been fixed, and tests are now running successfully.  
+- **Sina** confirmed that Geth has merged their PR (Pull Request) to fix parent block hashes, resolving some test case issues.  
+
+### Tracing PR Progress  
+- **Lukasz** mentioned the need to sync with **Deeptanshu** regarding the tracing PR but faced timing issues. The PR is in a good state but needs some polishing.  
+- **Killari** was invited to review the tracing PR to understand its workings.  
+- Noted discrepancies in how tracing is invoked compared to eth_simulate; a preferred approach would align its input and output structure to eth_simulate while incorporating tracing functionality.
+- **Lukasz** shared the PR in Telegram for further review, and **Killari** suggested **Sina** should also evaluate it.  
+- Nethermind and Geth tracing implementations were analyzed for alignment, with minor differences noted primarily in error messages rather than codes.
+
+### Gas Estimation Discussion  
+- The discussion revisited ongoing deliberations regarding gas estimation methodologies.
+- Previous meetings had yielded tentative options, but a final decision had yet to be reached.
+- Differing perspectives emerged regarding global gas flag usage, with concerns over potential overestimation in specific use cases, particularly in the Interceptor framework.
+- The need for selective transaction estimation was emphasized, advocating for an approach that allows developers to specify which transactions require estimation while ensuring efficiency in gas calculations.
+- A proposal was put forward to limit estimation within a predefined gas limit, with behavior ensuring that transactions would not exceed the user-defined cap.
+- The proposed method involves executing a transaction with the set gas limit and, upon failure, ceasing further estimation; if successful, further refinements would be applied within the limit.
+- A structured approach to decision-making was suggested, including drafting a proposal for broader community input, particularly from Nethermind and other relevant providers.
+- Concerns were raised regarding potential developer confusion if gas limit adjustments yielded widely varying estimates, prompting further discussion on ensuring predictability and usability.  
+
+### Implementation Preferences  
+- **Killari** and **Sina** discussed different approaches:  
+  - **Killari** preferred allowing users to specify which transactions to estimate.  
+  - **Sina** leaned towards a simpler global flag.  
+- The team debated whether the gas limit should be a **hard cap** or a **starting point** for estimation.  
+- **Micah** raised concerns about inconsistencies between implementations (e.g., Geth vs. Nethermind), emphasizing the need for consistency and usability.  
+
+## Next Steps  
+The team agreed to finalize a proposal for gas estimation, focusing on two main options:  
+1. **A per-transaction flag** to specify which transactions should be estimated.  
+2. **A global flag** to enable or disable gas estimation across all transactions.  
+
+**Kilari and Sina** will collaborate on drafting the proposal and share it with users, including **Infura and other providers**, for feedback.  
+Additionally, the team plans to reach out to a developer who previously used `eth_simulate` in a library for insights.  
+
+## Action Items  
+
+### **Killari and Sina**  
+- Finalize the gas estimation proposal and share it with stakeholders for feedback.  
+- Review the tracing PR and provide feedback on its alignment with `eth_simulate`.  
+
+### **Lukasz**  
+- Sync with **Deeptanshu** to finalize the tracing PR.  
+- Reach out to **Infura** and other providers to gather feedback on the gas estimation proposal.  
+
+### **Team**  
+- Continue testing and refining the fixed test cases.  
+- Prepare for the next meeting to review stakeholder feedback and finalize the gas estimation approach.  

--- a/Breakout-Room-Meetings/ETH-Simulate/Meeting 40.md
+++ b/Breakout-Room-Meetings/ETH-Simulate/Meeting 40.md
@@ -1,0 +1,55 @@
+# Eth_Simulate Meeting Meeting 40
+Note: This file is copied from [here](https://github.com/ethereum/pm/issues/1330)
+
+### Meeting Info
+
+- Agenda: [ethereum#1330](https://github.com/ethereum/pm/issues/1330#issue-2882886091)
+- Date & Time: March 03, 2025, 12:00 UTC
+- Recording: [here](https://youtu.be/uQeN-oem-r0)
+## Notes
+## Eth_Simulate Implementers Call Summary  
+
+## Overview
+The team discussed progress on estimations, tracing endpoints, and debugging efforts. Key topics included a write-up on two estimation approaches (global vs. core level flag), with a follow-up needed to confirm if Sina shared it. Updates were provided on the implementation of endpoints, debugging Nethermind, and tracing functionality, which is nearing completion but requires minor modifications. The team also highlighted the need to decide on the estimation approach and address failing tests once the tracing endpoints are finalized. Action items include pushing the estimation decision to the board, completing endpoint modifications, and sharing updates on Telegram.
+## Key Discussion Points
+
+A write-up was prepared last week regarding two approaches to estimations: the global estimation flag and the core level estimation flag.
+
+- The write-up aims to simplify discussions about the two options, allowing the team to proceed without Sina's direct involvement if necessary.
+- The team needs to decide which approach to adopt (global or local flag) for the simulate and estimate gas functionality.
+
+---
+
+## Updates on Endpoints and Debugging
+
+### Rohit's Update:
+- Worked on implementing three endpoints but identified some issues.
+- Currently modifying the implementation, with an expected completion by the end of the day.
+- Will post updates on Telegram once done.
+
+### Nethermind Debugging:
+- Progress was made on debugging Nethermind, though it was noted to be slightly challenging.
+- A PR will be created to modify Olex's previous PR for debugging with Nethermind Hive tests.
+- Once the trace endpoints are finalized, focus will shift back to addressing failing tests.
+
+---
+
+## Tracing Endpoints (Eth Simulates)
+
+- The implementation of tracing endpoints is nearly complete but requires modifications as per feedback from Lucas.
+- Expected completion: Today or tomorrow.
+- An intern, working with Tansu, was initially assigned to this task, but the responsibility has since been taken over by another team member.
+
+---
+
+## Other Updates
+
+- The primary focus remains on resolving the estimations discussion and completing the tracing endpoints.
+
+---
+
+## Next Steps:
+- Confirm with Sina regarding the write-up on estimation flags.
+- Finalize the decision on the global vs. local flag approach.
+- Complete modifications to the tracing endpoints and share updates on Telegram.
+- Address failing tests after the trace endpoints are finalized.

--- a/Breakout-Room-Meetings/ETH-Simulate/Meeting 41.md
+++ b/Breakout-Room-Meetings/ETH-Simulate/Meeting 41.md
@@ -1,0 +1,76 @@
+# Eth_Simulate Meeting Meeting 41
+Note: This file is copied from [here](https://github.com/ethereum/pm/issues/1352)
+
+### Meeting Info
+
+- Agenda: [ethereum#1352](https://github.com/ethereum/pm/issues/1352#issue-2898141594)
+- Date & Time: March 10, 2025, 12:00 UTC
+- Recording: [here](https://youtu.be/aTvdYmrZwi0)
+## Notes
+## Eth_Simulate Implementers Call Summary  
+
+## Estimate Gas Alternatives Document Update  
+
+- A document detailing estimated gas alternatives has been prepared and shared with two teams.  
+- Currently awaiting feedback from these teams; no significant updates to report at this time.  
+
+## Issue Raised: Beacon Route and Withdrawals Override  
+
+**Issue Overview:**  
+- A request was raised on a repository to enable overriding the beacon block root and withdrawals for a given block.  
+
+**Purpose:**  
+- The enhancement aims to improve the functionality of `eth_simulate`, allowing it to simulate the chain more comprehensively.  
+- This would enable users to test execution and consensus clients more effectively, essentially supporting a full fork of mainnet in memory.  
+
+**Current Status:**  
+- The feature is close to being fully functional, requiring only the addition of these two parameters.  
+
+## Discussion on Implementation  
+
+- **Consensus:** The team agreed that adding these parameters would be a non-breaking change and could be incorporated into version 1 (v1) of the software, as it is purely additive.  
+- **Client Alignment:** To ensure consistency, buy-in from all relevant clients is required. The identified clients are **Reth** and **Besu**.  
+
+**Next Steps:**  
+- Confirm awareness and agreement from **Reth** and **Besu** regarding the proposed changes.  
+- Ensure that both clients are comfortable with implementing the new parameters.  
+- Avoid scenarios where some clients support the feature while others do not, which could lead to inconsistencies in RPC method usage.  
+
+## Besu Testing Concerns  
+
+**Current Status:**  
+- The **Besu** team has not yet responded regarding the implementation of the proposed changes.  
+
+**Previous Issue:**  
+- Tests were failing due to a **parent hash issue in Geth**, which has since been resolved.  
+
+**Action Items:**  
+- Follow up with **Gabriel (from Besu)** via Telegram to confirm their current status and willingness to proceed with the changes.  
+- Verify if the fixed parent hash issue has allowed Besu to pass the previously failing tests.  
+
+## NetherMind Testing Update  
+
+**Reported Issues:**  
+- **Rohit** highlighted ongoing challenges with address endpoints, particularly a persistent **parent hash mismatch issue**.  
+
+**Recent Fixes:**  
+- Although the parent hash issue in Geth has been resolved and tests regenerated, the problem persists, suggesting a potential **secondary bug** in the same area.  
+  
+
+**Recommendation:**  
+- Engage a **third client (e.g., Reth)** in the testing process to provide additional validation and help pinpoint issues more effectively.  
+- Ensure that at least two out of three clients are aligned to facilitate better debugging and issue resolution.  
+
+## Next Steps and Action Items  
+
+### **Beacon Route and Withdrawals Override:**  
+- Confirm buy-in from **Reth** and **Besu** for the proposed changes.  
+- Ensure all clients are aligned to avoid inconsistencies in implementation.  
+
+### **Besu Testing Follow-Up:**  
+- Contact **Gabriel (Besu)** to confirm their status and willingness to proceed.  
+- Verify if the fixed parent hash issue has resolved their test failures.  
+
+### **NetherMind Testing:**  
+- Continue monitoring and debugging the **parent hash mismatch issue**.  
+- Encourage a **third client (e.g., Reth)** to participate in testing to improve reliability and issue diagnosis.  

--- a/Breakout-Room-Meetings/ETH-Simulate/Meeting 42.md
+++ b/Breakout-Room-Meetings/ETH-Simulate/Meeting 42.md
@@ -1,0 +1,129 @@
+# Eth_Simulate Meeting Meeting 42
+Note: This file is copied from [here](https://github.com/ethereum/pm/issues/1387)
+
+### Meeting Info
+
+- Agenda: [ethereum#1387](https://github.com/ethereum/pm/issues/1387#issue-2925132165)
+- Date & Time: March 17, 2025, 12:00 UTC
+- Recording: [here](https://youtu.be/Lcd7_CDKV7w)
+## Notes
+## Eth_Simulate Implementers Call Summary  
+
+## 1.1 Killari  
+Killari did not provide any updates as they were on holiday the previous week.  
+
+## 1.2 Sina  
+Sina also had no updates to share during this meeting.  
+
+## 1.3 Rohit  
+Rohit provided several updates on his recent work:  
+
+### Endpoint Implementations  
+- He successfully implemented two pressing endpoints: one in the **Parity style** and the other in the **Geth style**.  
+- These implementations are part of ongoing efforts to ensure compatibility and functionality across different Ethereum clients.  
+
+### Hash Mismatch Issue  
+- Rohit identified a potential issue related to request hashes.  
+- Nethermind does not incorporate request hashes in its responses, whereas Geth does, which could lead to mismatches.  
+- **Next Steps:**  
+  - Rohit plans to investigate this further and will share detailed findings with the team for review.  
+  - He emphasized the importance of aligning Nethermind’s behavior with Geth to avoid inconsistencies.  
+
+---
+
+## 2. Debug and Tracing Endpoints Discussion  
+
+### 2.1 Debug and Tracing Endpoint Specifications  
+The team discussed the specifications for debug and tracing endpoints, focusing on input and output formats.  
+
+#### Input and Output Details  
+- Rohit shared the input and output specifications for the debug and tracing endpoints.  
+- The PR for this implementation is not yet merged, but the team reviewed the details to ensure alignment with expectations.  
+- **Outputs include:**  
+  - Structured logs  
+  - Call objects (providing detailed information about transaction execution)  
+
+### Review and Approval  
+- The PR is currently under review and is expected to be approved soon.  
+- **Next Steps:**  
+  - **Sina** was asked to review the implementation to ensure it aligns with expected standards and practices.  
+  - The team emphasized the importance of **Sina’s approval** before merging the PR due to his expertise in tracing implementations.  
+
+### 2.2 Parity Tracing Compatibility  
+The team also discussed the compatibility of **Parity tracing** with other Ethereum clients.  
+
+#### Support in Other Nodes  
+- **Geth does not support Parity tracing**, but other clients like **Reth** might have some level of compatibility.  
+- **Next Steps:**  
+  - The team plans to seek feedback from other client developers, such as **Gabriel**, to ensure the implementation aligns with broader standards.  
+
+---
+
+## 3. Debug Tracing Implementation Details  
+
+### 3.1 Struct Logs and Call Objects  
+The team discussed **struct logs** and **call objects**, key components of the debug tracing implementation.  
+
+### Struct Logs Added to Call Objects  
+Struct logs provide detailed transaction execution information, including:  
+- **Program Counter (PC):** Indicates the current instruction being executed.  
+- **Opcode:** The operation being performed.  
+- **Gas:** The amount of gas used and remaining.  
+- **Gas Call Steps:** Details about gas consumption during execution.  
+
+### Comparison with Debug Trace  
+- The format of struct logs appears consistent with **debug trace outputs**, ensuring compatibility with existing tools and practices.  
+
+### 3.2 Pre-State Tracing  
+The team discussed **pre-state tracing**, which provides insights into blockchain state before a transaction executes.  
+
+#### Functionality  
+- Pre-state tracing reveals which parts of the state are required for execution and their values before execution.  
+
+#### Inclusion in Response  
+- The team agreed to **include pre-state trace results** in the same response structure as other traces.  
+- This approach reduces the need for multiple API calls and improves usability.  
+
+### 3.3 Tracer Configuration and Parameters  
+The team reviewed **configuration options** for debug tracing.  
+
+#### Optional Parameters  
+- Like Geth, the implementation allows users to specify **optional configuration objects**, such as selecting a specific tracer.  
+
+#### Input Consistency  
+- The input format for debug tracing remains consistent with standard tracing methods, ensuring **ease of use** and **compatibility**.  
+
+---
+
+# 4. Challenges and Considerations  
+
+### 4.1 Payload Limits  
+Debug tracing can generate **large outputs**, which may exceed payload limits.  
+
+### Risk of Hitting Limits  
+- Tracing multiple transactions within a block can result in **very large responses**, potentially exceeding RPC provider limits.  
+
+### Mitigation Strategies  
+- **Local nodes** can adjust payload limits to accommodate larger responses.  
+- **Public endpoints** may need to disable or restrict debug tracing to prevent performance issues.  
+
+### 4.2 Standardization of Tracing Formats  
+The team discussed the challenges of **standardizing tracing formats** across Ethereum clients.  
+
+### Current Inconsistencies  
+- Differences in how **Geth** and **Nethermind** handle tracing outputs (e.g., request hashes) can lead to **compatibility issues**.  
+
+### Future Efforts  
+- Ongoing Efforts aim to standardize tracing formats, particularly for **EOF (Ethereum Object Format) execution**.  
+- These efforts seek to create a **unified approach** to tracing across clients.  
+
+---
+
+## 5. Next Steps  
+
+- **PR Review and Approval:** Sina will review the PR for the debug tracing implementation and provide feedback.  
+- **Hash Mismatch Investigation:** Rohit will continue investigating the hash mismatch issue and share findings with the team.  
+  
+- **Feedback from Other Clients:** The team will seek feedback from other Ethereum client developers (e.g., Gabriel) to ensure compatibility.  
+- **Implementation of Gas Estimation Features:**  
+  - The team plans to prioritize **gas estimation features** for **Eth_Simulate V2**, as it is a high-priority task.  


### PR DESCRIPTION
This PR includes updates on the ETH-Simulate meetings held between February 24 and March 17 2025. The updates contain:

   📅 Meeting notes summarizing key discussions
    📜 Agendas for each session
    🔗 YouTube links to the recorded meetings
    📝 Additional references & resources