### PR TITLE
Add Lodestar coordinators for Pectra fork

### DIFF
--- a/Pectra/pectra-mainnet-plan.md
+++ b/Pectra/pectra-mainnet-plan.md
@@ -16,7 +16,7 @@
 | Geth | [Name] | [Name] |
 | Grandine | [Name] | [Name] |
 | Lighthouse | [Name] | [Name] |
-| Lodestar | [Name] | [Name] |
+| Lodestar | Phil Ngo | Nico Flaig |
 | Nimbus | [Name] | [Name] |
 | Nethermind | [Name] | [Name] |
 | Prysm | [Name] | [Name] |


### PR DESCRIPTION
This update adds Lodestar's coordinators for the Pectra fork.