### PR TITLE
Add Nethermind Pectra coordinators

### DIFF
--- a/Pectra/pectra-mainnet-plan.md
+++ b/Pectra/pectra-mainnet-plan.md
@@ -18,7 +18,7 @@
 | Lighthouse | Sean Anderson | Michael Sproul |
 | Lodestar | Phil Ngo | Nico Flaig |
 | Nimbus | Dustin | Advaita Saha |
-| Nethermind | [Name] | [Name] |
+| Nethermind | Marek Moraczyński | Łukasz Rozmej <br> Kamil Chodoła <br> Ahmad Bitar |
 | Prysm | Ping @prysmatic in the Eth R&D Discord | prysm@offchainlabs.com |
 | Reth | Roman Krasiuk | Matthias Seitz |
 | Teku | Enrico Del Fante | Paul Harris |


### PR DESCRIPTION
Not sure if adding more than 1 backup will create more confusion or be helpful. We can trim to 2 or 1 in current order.