### PR TITLE
docs: fix typos

### DIFF
--- a/Fusaka/peerdas-readiness.md
+++ b/Fusaka/peerdas-readiness.md
@@ -56,7 +56,7 @@ https://docs.google.com/document/d/1MXf5zTU58mRj0Yq88EPBP1gCJzWTY9FRfUdpZjcfgqw/
 ## Testing
 
 * [ ] Tooling updates
-  * [ ] `spamoor` needs updating to use the new tx format, potentially we need a way to make sure clients are indeed adhering this change
+  * [ ] `spamoor` needs updating to use the new tx format, potentially we need a way to make sure clients are indeed adhering to this change
 * [ ] [EELS](https://github.com/ethereum/execution-specs) Implementation
 * [ ] [EEST](https://github.com/ethereum/execution-spec-tests) Tests
 * [ ] Hive
@@ -72,7 +72,7 @@ https://docs.google.com/document/d/1MXf5zTU58mRj0Yq88EPBP1gCJzWTY9FRfUdpZjcfgqw/
  
 ## R&D
 
-* [ ] Anaylsis of new blob count impact on bandwidth, hardware requirements once clients are feature complete (`peerdas-devnet-6`)
+* [ ] Analysis of new blob count impact on bandwidth, hardware requirements once clients are feature complete (`peerdas-devnet-6`)
 * [ ] Nice to have: [BPO only forks](https://ethereum-magicians.org/t/blob-parameter-only-bpo-forks/22623)
 * [ ] EL: Potential optimisation of `getBlobs` endpoint?
 * [ ] Document impact to node operators (prior post with 16 blobs [here](https://blog.sigmaprime.io/peerdas-distributed-blob-building.html#impact-on-node-operators))


### PR DESCRIPTION
spotted a couple of small things and figured I'd clean them up:  
- Fixed "Anaylsis" → "Analysis"  
- Changed "adhering this change" → "adhering to this change"  

nothing major, just keeping things tidy.