### PR TITLE
fix: ACDC artifacts posting to the wrong thread ID

### DIFF
--- a/.github/ACDbot/meeting_topic_mapping.json
+++ b/.github/ACDbot/meeting_topic_mapping.json
@@ -208,7 +208,7 @@
       {
         "issue_number": 1579,
         "issue_title": "All Core Devs - Consensus (ACDC) #159, June 26 2025",
-        "discourse_topic_id": 24208,
+        "discourse_topic_id": 24584,
         "start_time": "2025-06-26T14:00:00Z",
         "duration": 90,
         "skip_youtube_upload": true,

--- a/.github/workflows/issue-workflow.yml
+++ b/.github/workflows/issue-workflow.yml
@@ -217,4 +217,8 @@ permissions:
   contents: write 
   issues: write   
 
+# Prevent concurrent runs of the same issue
+concurrency:
+  group: issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
 


### PR DESCRIPTION
A bug occurred where ACDC 159 call [artifacts](https://ethereum-magicians.org/t/all-core-devs-consensus-acdc-158-may-29-2025/24208/12?u=marcgarreau) were posted in the ACDC 158 thread.

It appears one of the github actions that [updated](https://github.com/ethereum/pm/commit/b760536656e569094f96d7e5b12718a48f2c09e6) the stream url also overwrote the `discourse_topic_id`.

I believe what happened is that the `issue-workflow` was triggered in quick succession after the github issue was opened and then edited while the first github action was ongoing. The second github action kicked off and reported `[DEBUG] No previous mapping entry found containing issue #1579. Assuming new meeting context.`, so it tried to create the forum post (again), got a "Title has already been used" error, then went to fallback methods.

This PR:
- corrects the topic ID for ACDC 159
- prevents valid overwrites in the future
- prevents concurrent github actions for the same issue being updated; the next will start once the first completes.