### PR TITLE
add nixorokish to issue trustedContributors

### DIFF
--- a/.github/workflows/issue-workflow.yml
+++ b/.github/workflows/issue-workflow.yml
@@ -25,7 +25,7 @@ jobs:
               "poojaranjan", "adietrichs", "carlbeek", "timbeiko", "nconsigny", 
               "justindrake", "vbuterin", "hwwhww", "mathhhewkeil", "jrudolf", 
               "soispoke", "pipermerriam", "potuz", "will-corcoran", "ralexstokes", 
-              "samwilsn", "shemnon"
+              "samwilsn", "shemnon", "nixorokish"
             ];
             
             console.log(`Checking membership for user: ${username}`);


### PR DESCRIPTION
bug occurring now where nixo is not identified as an org member (possibly just an api down, to be debugged next). quick fix to add handle to the trusted list, which is appropriate anyway.