### PR TITLE
Fix broken link in London ecosystem readiness document

### DIFF
--- a/Network-Upgrade-Archive/London/london-ecosystem-readinesss.md
+++ b/Network-Upgrade-Archive/London/london-ecosystem-readinesss.md
@@ -7,7 +7,7 @@ If you know about a status update please add a PR to this document or post on th
 
 ## London Network Upgrade
 
-For a list of included EIPs see the [specification](./mainnet-upgrades/london.md) document.
+For a list of included EIPs see the [EIP-1559 specification](https://eips.ethereum.org/EIPS/eip-1559) and the [London upgrade announcement](https://blog.ethereum.org/2021/07/15/london-mainnet-announcement).
 
 Tracking: `active`
 ⭕ - Not Started


### PR DESCRIPTION


### What changed
- Fixed broken internal link to non-existent `./mainnet-upgrades/london.md` file
- Replaced with proper external links to:
  - [EIP-1559 specification](https://eips.ethereum.org/EIPS/eip-1559)
  - [London upgrade announcement](https://blog.ethereum.org/2021/07/15/london-mainnet-announcement)

### Why this change
The document referenced a local file that doesn't exist in the repository, creating a broken link for users trying to access London upgrade specifications.

### File changed
- `Network-Upgrade-Archive/London/london-ecosystem-readinesss.md`

