### PR TITLE
fix: update Google Calendar link to public version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository is for:
 - [L2 interop](https://github.com/ethereum/pm/issues?q=is%3Aissue%20label%3AL2%20)
  breakout meetings
 
-Agendas for these meetings can be found on the [Issues](https://github.com/ethereum/pm/issues) tab. This [Google Calendar](https://calendar.google.com/calendar/u/0?cid=Y191cGFvZm9uZzhtZ3JtcmtlZ243aWM3aGs1c0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) also tracks upcoming protocol meetings.
+Agendas for these meetings can be found on the [Issues](https://github.com/ethereum/pm/issues) tab. This [Google Calendar](https://calendar.google.com/calendar/embed?src=c_upaofong8mgrmrkegn7ic7hk5s%40group.calendar.google.com) also tracks upcoming protocol meetings.
 
 Past meetings with call summaries, related links, and discussions can be found on [Ethereum Magicians](https://ethereum-magicians.org/c/protocol-calls/63).
 


### PR DESCRIPTION
The current Google Calendar link in the README is only visible to users signed into a Google account, which limits accessibility. This PR updates the link to a publicly accessible version of the calendar, ensuring everyone can view it without requiring Google authentication.