### PR TITLE
acdbot: simplify one-off calls

### DIFF
--- a/.github/ACDbot/meeting_topic_mapping.json
+++ b/.github/ACDbot/meeting_topic_mapping.json
@@ -1751,29 +1751,34 @@
     ],
     "calendar_event_id": "9okshav08smlth9a7k83gtkcl4_20250805T160000Z"
   },
-  "one-off": {
-    "89880194464": {
-      "discourse_topic_id": 23010,
-      "issue_title": "Holesky Validator Incident Response Call | February 28, 2025",
-      "start_time": "2025-02-28T15:00:00Z",
-      "duration": 60,
-      "issue_number": 1337,
-      "meeting_id": "89880194464",
-      "youtube_upload_processed": true,
-      "transcript_processed": true,
-      "upload_attempt_count": 1,
-      "transcript_attempt_count": 0,
-      "calendar_event_id": "bDJyNHBxbms2c2Jpc25nZ2dkMW9hYm9sNWcgY191cGFvZm9uZzhtZ3JtcmtlZ243aWM3aGs1c0Bn",
-      "telegram_message_id": 45,
-      "youtube_video_id": "oacAxtKC6rQ",
-      "notifications": [
-        {
-          "type": "youtube_upload",
-          "content": "Meeting recording uploaded: Holesky Validator Incident Response Call | February 28, 2025",
-          "timestamp": "2025-03-27T03:30:19.716750+00:00",
-          "url": "https://youtu.be/oacAxtKC6rQ"
-        }
-      ]
-    }
+  "one-off-1337": {
+    "call_series": "one-off-1337",
+    "meeting_id": "89880194464",
+    "occurrence_rate": "one-time",
+    "occurrences": [
+      {
+        "occurrence_number": 1,
+        "issue_number": 1337,
+        "issue_title": "Holesky Validator Incident Response Call | February 28, 2025",
+        "discourse_topic_id": 23010,
+        "start_time": "2025-02-28T15:00:00Z",
+        "duration": 60,
+        "youtube_upload_processed": true,
+        "transcript_processed": true,
+        "upload_attempt_count": 1,
+        "transcript_attempt_count": 0,
+        "calendar_event_id": "bDJyNHBxbms2c2Jpc25nZ2dkMW9hYm9sNWcgY191cGFvZm9uZzhtZ3JtcmtlZ243aWM3aGs1c0Bn",
+        "telegram_message_id": 45,
+        "youtube_video_id": "oacAxtKC6rQ",
+        "notifications": [
+          {
+            "type": "youtube_upload",
+            "content": "Meeting recording uploaded: Holesky Validator Incident Response Call | February 28, 2025",
+            "timestamp": "2025-03-27T03:30:19.716750+00:00",
+            "url": "https://youtu.be/oacAxtKC6rQ"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/ACDbot/meeting_topic_mapping.json
+++ b/.github/ACDbot/meeting_topic_mapping.json
@@ -731,7 +731,6 @@
           }
         ],
         "occurrence_number": 15,
-        "meeting_id": 84937733625,
         "calendar_event_id": "d4n61s950fn41c10a9a3pdrnk4"
       },
       {
@@ -776,7 +775,6 @@
         "start_time": "2025-03-05T15:00:00Z",
         "duration": 60,
         "issue_number": 1312,
-        "meeting_id": "88175022289",
         "youtube_upload_processed": false,
         "transcript_processed": false,
         "upload_attempt_count": 0,
@@ -821,6 +819,7 @@
   "beam": {
     "call_series": "beam",
     "occurrence_rate": "other",
+    "meeting_id": null,
     "occurrences": [
       {
         "occurrence_number": 1,
@@ -829,7 +828,6 @@
         "start_time": "2025-04-18T14:00:00Z",
         "duration": 60,
         "issue_number": 1446,
-        "meeting_id": "89498939501",
         "youtube_upload_processed": false,
         "transcript_processed": false,
         "upload_attempt_count": 0,
@@ -881,7 +879,6 @@
         "start_time": "2025-04-04T14:00:00Z",
         "duration": 60,
         "issue_number": 1448,
-        "meeting_id": "85985455392",
         "zoom_link": "https://ethereumfoundation.zoom.us/j/85985455392?pwd=erkXoJfo90oIcoImtXx3BCRnSb3IyU.1",
         "youtube_upload_processed": false,
         "transcript_processed": false,
@@ -941,7 +938,6 @@
         "start_time": "2025-04-15T14:00:00Z",
         "duration": 60,
         "issue_number": 1441,
-        "meeting_id": "82243310118",
         "youtube_upload_processed": false,
         "transcript_processed": false,
         "upload_attempt_count": 0,
@@ -994,6 +990,7 @@
   "evmmax": {
     "call_series": "evmmax",
     "occurrence_rate": "other",
+    "meeting_id": null,
     "occurrences": [
       {
         "occurrence_number": 1,
@@ -1002,7 +999,6 @@
         "start_time": "2025-04-24T12:00:00Z",
         "duration": 90,
         "issue_number": 1469,
-        "meeting_id": "88182008145",
         "youtube_upload_processed": false,
         "transcript_processed": false,
         "upload_attempt_count": 0,
@@ -1067,7 +1063,6 @@
         "telegram_message_id": 92,
         "youtube_streams": null,
         "youtube_streams_posted_to_discourse": false,
-        "meeting_id": "86455425711",
         "calendar_event_id": "3pjjv7242lq840jo942or55bpk"
       },
       {
@@ -1491,7 +1486,7 @@
   },
   "protocolresearch": {
     "call_series": "protocolresearch",
-    "meeting_id": "placeholder-research-call",
+    "meeting_id": null,
     "occurrence_rate": "other",
     "occurrences": [
       {

--- a/.github/ACDbot/modules/mapping_utils.py
+++ b/.github/ACDbot/modules/mapping_utils.py
@@ -37,24 +37,11 @@ def find_meeting_by_id(meeting_id: str, mapping: Dict) -> Optional[Dict]:
     """
     meeting_id = str(meeting_id)
 
-    for call_series, series_data in mapping.items():
-        if call_series == "one-off":
-            # Check one-off entries (meeting_id is the key)
-            if meeting_id in series_data:
-                return series_data[meeting_id]
-        else:
-            # For recurring series, check both root level and occurrences
-            # Ensure series_data is a dictionary
-            if not isinstance(series_data, dict):
-                continue
-
-            if series_data.get("meeting_id") == meeting_id:
-                return series_data
-
-            # Check occurrences for meeting_id overrides
-            for occurrence in series_data.get("occurrences", []):
-                if occurrence.get("meeting_id") == meeting_id:
-                    return occurrence
+    for _, series_data in mapping.items():
+        if not isinstance(series_data, dict):
+            continue
+        if series_data.get("meeting_id") == meeting_id:
+            return series_data
 
     return None
 
@@ -70,17 +57,10 @@ def find_meeting_by_issue_number(issue_number: int, mapping: Dict) -> Optional[D
     Returns:
         The meeting entry if found, None otherwise
     """
-    for call_series, series_data in mapping.items():
-        if call_series == "one-off":
-            # Check one-off entries
-            for zoom_id, entry_data in series_data.items():
-                if entry_data.get("issue_number") == issue_number:
-                    return entry_data
-        else:
-            # Check recurring series occurrences
-            for occurrence in series_data.get("occurrences", []):
-                if occurrence.get("issue_number") == issue_number:
-                    return occurrence
+    for _, series_data in mapping.items():
+        for occurrence in series_data.get("occurrences", []):
+            if occurrence.get("issue_number") == issue_number:
+                return occurrence
 
     return None
 
@@ -112,7 +92,7 @@ def find_occurrence_by_issue_number(call_series: str, issue_number: int, mapping
         The occurrence entry if found, None otherwise
     """
     series_data = mapping.get(call_series)
-    if not series_data or call_series == "one-off":
+    if not series_data:
         return None
 
     for occurrence in series_data.get("occurrences", []):
@@ -182,64 +162,36 @@ def add_occurrence_to_series(call_series: str, occurrence_data: Dict, mapping: D
     mapping[call_series]["occurrences"].append(occurrence_data)
     return True
 
-
-# Removed unused functions: get_all_meeting_ids, get_all_occurrences, find_meeting_with_recording
-# These functions are not used by any existing scripts and can be added back if needed later
-
-
 def get_effective_meeting_id(call_series: str, issue_number: int, mapping: Dict) -> Optional[str]:
     """
-    Get the effective meeting ID for a specific occurrence.
-
-    This function implements the hybrid approach:
-    - If occurrence has its own meeting_id, use that
-    - Otherwise, fall back to the root level meeting_id
-    - If neither exists, return None
+    Get the meeting ID for a specific call series.
 
     Args:
         call_series: The call series name
-        issue_number: The GitHub issue number
+        issue_number: The GitHub issue number (unused, kept for API compatibility)
         mapping: The mapping dictionary
 
     Returns:
-        The effective meeting ID, or None if not found
+        The meeting ID, or None if not found
     """
     series_data = mapping.get(call_series)
     if not series_data:
         return None
 
-    if call_series == "one-off":
-        # For one-off calls, meeting_id is the key
-        for meeting_id, entry_data in series_data.items():
-            if entry_data.get("issue_number") == issue_number:
-                return str(meeting_id)
-        return None
-
-    # For recurring series, find the occurrence
-    occurrence = find_occurrence_by_issue_number(call_series, issue_number, mapping)
-    if not occurrence:
-        return None
-
-    # Check if occurrence has its own meeting_id (override)
-    occurrence_meeting_id = occurrence.get("meeting_id")
-    if occurrence_meeting_id:
-        return str(occurrence_meeting_id)
-
-    # Fall back to root level meeting_id
-    root_meeting_id = series_data.get("meeting_id")
-    if root_meeting_id:
-        return str(root_meeting_id)
+    meeting_id = series_data.get("meeting_id")
+    if meeting_id:
+        return str(meeting_id)
 
     return None
 
 
 def find_call_series_by_meeting_id(meeting_id: str, occurrence_issue_number: int, mapping: Dict) -> Optional[str]:
     """
-    Find the call series for a given meeting ID and issue number.
+    Find the call series for a given meeting ID.
 
     Args:
         meeting_id: The Zoom meeting ID to search for
-        occurrence_issue_number: The GitHub issue number to match
+        occurrence_issue_number: The GitHub issue number (unused, kept for API compatibility)
         mapping: The mapping dictionary
 
     Returns:
@@ -248,26 +200,12 @@ def find_call_series_by_meeting_id(meeting_id: str, occurrence_issue_number: int
     meeting_id = str(meeting_id)
 
     for call_series, series_data in mapping.items():
-        if call_series == "one-off":
-            # Check one-off entries
-            if meeting_id in series_data:
-                return call_series
-        else:
-            # For recurring series, check both root level and occurrences
-            if not isinstance(series_data, dict):
-                continue
+        if not isinstance(series_data, dict):
+            continue
 
-            # Check if this is the series-level meeting ID
-            if series_data.get("meeting_id") == meeting_id:
-                # Find the occurrence with matching issue number
-                for occurrence in series_data.get("occurrences", []):
-                    if occurrence.get("issue_number") == occurrence_issue_number:
-                        return call_series
-
-            # Check occurrences for meeting_id overrides
-            for occurrence in series_data.get("occurrences", []):
-                if occurrence.get("meeting_id") == meeting_id and occurrence.get("issue_number") == occurrence_issue_number:
-                    return call_series
+        # Check if this is the series-level meeting ID
+        if series_data.get("meeting_id") == meeting_id:
+            return call_series
 
     return None
 
@@ -287,28 +225,20 @@ def validate_mapping_structure(mapping: Dict) -> bool:
             if not isinstance(series_data, dict):
                 return False
 
-            if call_series == "one-off":
-                # One-off entries should have meeting_id as keys
-                for zoom_id, entry_data in series_data.items():
-                    if not isinstance(entry_data, dict):
-                        return False
-                    if "issue_number" not in entry_data:
-                        return False
-            else:
-                # Recurring series should have call_series and occurrences
-                if "call_series" not in series_data:
-                    return False
-                if "occurrences" not in series_data:
-                    return False
-                if not isinstance(series_data["occurrences"], list):
-                    return False
+            # All series should have call_series and occurrences
+            if "call_series" not in series_data:
+                return False
+            if "occurrences" not in series_data:
+                return False
+            if not isinstance(series_data["occurrences"], list):
+                return False
 
-                # Validate occurrences
-                for occurrence in series_data["occurrences"]:
-                    if not isinstance(occurrence, dict):
-                        return False
-                    if "issue_number" not in occurrence:
-                        return False
+            # Validate occurrences
+            for occurrence in series_data["occurrences"]:
+                if not isinstance(occurrence, dict):
+                    return False
+                if "issue_number" not in occurrence:
+                    return False
 
         return True
     except Exception:

--- a/.github/ACDbot/scripts/discord_notify.py
+++ b/.github/ACDbot/scripts/discord_notify.py
@@ -18,41 +18,23 @@ def main():
         return
     now = datetime.now(timezone.utc)
 
-    # Process all call series and one-off meetings
     for call_series, series_data in mapping.items():
-        if call_series == "one-off":
-            # Process one-off meetings
-            for meeting_id, entry in series_data.items():
-                start_time = entry.get("start_time")
-                if not start_time:
-                    continue
-                try:
-                    start_dt = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
-                except Exception:
-                    continue
-                seconds_until = (start_dt - now).total_seconds()
-                if 0 <= seconds_until <= NOTIFY_WINDOW_MINUTES * 60:
-                    title = entry.get("issue_title", "One-off Meeting")
-                    issue_number = entry.get("issue_number")
-                    message = f"Reminder: {title} (issue #{issue_number}) starts at {start_dt.strftime('%H:%M UTC')}!"
-                    send_discord_notification("one-off", message)
-        else:
-            # Process recurring series occurrences
-            call_series_lower = call_series.lower()
-            for occurrence in series_data.get("occurrences", []):
-                start_time = occurrence.get("start_time")
-                if not start_time:
-                    continue
-                try:
-                    start_dt = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
-                except Exception:
-                    continue
-                seconds_until = (start_dt - now).total_seconds()
-                if 0 <= seconds_until <= NOTIFY_WINDOW_MINUTES * 60:
-                    title = occurrence.get("issue_title", f"{call_series.upper()} Meeting")
-                    issue_number = occurrence.get("issue_number")
-                    message = f"Reminder: {title} (issue #{issue_number}) starts at {start_dt.strftime('%H:%M UTC')}!"
-                    send_discord_notification(call_series_lower, message)
+        # Process all series occurrences (including one-off calls)
+        call_series_lower = call_series.lower()
+        for occurrence in series_data.get("occurrences", []):
+            start_time = occurrence.get("start_time")
+            if not start_time:
+                continue
+            try:
+                start_dt = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
+            except Exception:
+                continue
+            seconds_until = (start_dt - now).total_seconds()
+            if 0 <= seconds_until <= NOTIFY_WINDOW_MINUTES * 60:
+                title = occurrence.get("issue_title", f"{call_series.upper()} Meeting")
+                issue_number = occurrence.get("issue_number")
+                message = f"Reminder: {title} (issue #{issue_number}) starts at {start_dt.strftime('%H:%M UTC')}!"
+                send_discord_notification(call_series_lower, message)
 
 if __name__ == "__main__":
     main()

--- a/.github/ACDbot/scripts/handle_protocol_call.py
+++ b/.github/ACDbot/scripts/handle_protocol_call.py
@@ -169,7 +169,7 @@ class ProtocolCallHandler:
                 return False
 
             # 2. Parse form data
-            form_data = self._parse_form_data(issue.body)
+            form_data = self._parse_form_data(issue.body, issue_number)
             if not form_data:
                 print(f"[ERROR] Failed to parse form data from issue #{issue_number}")
                 return False
@@ -287,11 +287,11 @@ class ProtocolCallHandler:
             print(f"[ERROR] Failed to get GitHub issue: {e}")
             return None
 
-    def _parse_form_data(self, issue_body: str) -> Optional[Dict]:
+    def _parse_form_data(self, issue_body: str, issue_number: int) -> Optional[Dict]:
         """Parse form data from issue body."""
         try:
             print(f"[DEBUG] Raw issue body:\n{issue_body}")
-            form_data = self.form_parser.parse_form_data(issue_body)
+            form_data = self.form_parser.parse_form_data(issue_body, issue_number)
             print(f"[DEBUG] Successfully parsed form data: {form_data}")
             return form_data
 
@@ -348,15 +348,8 @@ class ProtocolCallHandler:
             occurrence = call_series_entry["occurrence"]
 
             # Check for existing resources
-            # For recurring calls, check series-level meeting ID; for one-off, check occurrence-level
-            if call_data.get("call_series") and call_data.get("call_series") != "one-off":
-                # For recurring calls, check if we have a series meeting ID
-                series_meeting_id = self.mapping_manager.get_series_meeting_id(call_data["call_series"])
-                has_zoom = bool(series_meeting_id and not str(series_meeting_id).startswith("placeholder"))
-            else:
-                # For one-off calls, check occurrence-level meeting ID
-                has_zoom = (occurrence.get("meeting_id") and
-                           not str(occurrence.get("meeting_id")).startswith("placeholder"))
+            series_meeting_id = self.mapping_manager.get_series_meeting_id(call_data["call_series"])
+            has_zoom = bool(series_meeting_id and not str(series_meeting_id).startswith("placeholder"))
 
             # Calendar event ID is stored at the parent level (call series level)
             call_series = call_series_entry.get("call_series")

--- a/.github/ACDbot/tests/conftest.py
+++ b/.github/ACDbot/tests/conftest.py
@@ -29,24 +29,35 @@ def sample_mapping():
                 {
                     "occurrence_number": 2,
                     "issue_number": 1463,
-                    "meeting_id": "86109593250",
                     "discourse_topic_id": 23503,
                     "start_time": "2025-05-08T14:00:00Z",
                     "duration": 90
                 }
             ]
         },
-        "one-off": {
-            "89880194464": {
-                "issue_number": 1465,
-                "meeting_id": "89880194464",
-                "discourse_topic_id": 23010
-            },
-            "99999999999": {
-                "issue_number": 1466,
-                "meeting_id": "99999999999",
-                "discourse_topic_id": 23011
-            }
+        "one-off-1465": {
+            "call_series": "one-off-1465",
+            "meeting_id": "89880194464",
+            "occurrence_rate": "one-time",
+            "occurrences": [
+                {
+                    "occurrence_number": 1,
+                    "issue_number": 1465,
+                    "discourse_topic_id": 23010
+                }
+            ]
+        },
+        "one-off-1466": {
+            "call_series": "one-off-1466",
+            "meeting_id": "99999999999",
+            "occurrence_rate": "one-time",
+            "occurrences": [
+                {
+                    "occurrence_number": 1,
+                    "issue_number": 1466,
+                    "discourse_topic_id": 23011
+                }
+            ]
         }
     }
 

--- a/.github/ACDbot/tests/unit/test_form_parser.py
+++ b/.github/ACDbot/tests/unit/test_form_parser.py
@@ -114,6 +114,7 @@ All Core Devs - Execution
         """Test parsing one-off meeting form data."""
         parser = FormParser()
 
+        # Test without issue number (should return "one-off")
         result = parser.parse_form_data(ONE_OFF_MEETING_FORM)
 
         assert result is not None
@@ -125,6 +126,10 @@ All Core Devs - Execution
         assert result["need_youtube_streams"] is False
         assert result["display_zoom_link_in_invite"] is False
         assert result["facilitator_emails"] == ['organizer@example.com']
+
+        # Test with issue number (should return "one-off-123")
+        result_with_issue = parser.parse_form_data(ONE_OFF_MEETING_FORM, 123)
+        assert result_with_issue["call_series"] == "one-off-123"
 
     def test_parse_form_data_missing_required_fields(self):
         """Test parsing form data with missing required fields."""
@@ -182,7 +187,7 @@ All Core Devs - Execution
         test_cases = [
             ("All Core Devs - Execution", "acde"),
             ("All Core Devs - Consensus", "acdc"),
-            ("One-time call", "one-off"),
+            ("One-time call", "one-off"),  # Without issue number
         ]
 
         for display_name, expected_key in test_cases:
@@ -190,6 +195,12 @@ All Core Devs - Execution
                 form_body = CALL_SERIES_TEST_FORMS[display_name]
                 result = parser.parse_form_data(form_body)
                 assert result["call_series"] == expected_key, f"Failed for: {display_name}"
+
+        # Test one-off with issue number
+        if "One-time call" in CALL_SERIES_TEST_FORMS:
+            form_body = CALL_SERIES_TEST_FORMS["One-time call"]
+            result = parser.parse_form_data(form_body, 456)
+            assert result["call_series"] == "one-off-456", "Failed for One-time call with issue number"
 
     def test_parse_form_data_occurrence_rate_mapping(self):
         """Test occurrence rate display name to key mapping."""

--- a/.github/ACDbot/tests/unit/test_mapping_manager.py
+++ b/.github/ACDbot/tests/unit/test_mapping_manager.py
@@ -134,15 +134,14 @@ class TestMappingManager:
             "issue_title": "One-off Meeting",
             "start_time": "2025-04-24T14:00:00Z",
             "duration": 90,
-            "meeting_id": "123456789"  # Required for one-off calls
+            "meeting_id": "123456789"
         }
 
-        success = manager.add_occurrence("one-off", occurrence_data)
+        success = manager.add_occurrence("one-off-1465", occurrence_data)
         assert success is True
-        assert "one-off" in manager.mapping
-        # One-off calls use meeting_id as the key
-        assert "123456789" in manager.mapping["one-off"]
-        assert manager.mapping["one-off"]["123456789"]["issue_number"] == 1465
+        assert "one-off-1465" in manager.mapping
+        assert manager.mapping["one-off-1465"]["meeting_id"] == "123456789"
+        assert manager.mapping["one-off-1465"]["occurrences"][0]["issue_number"] == 1465
 
     def test_add_occurrence_invalid_data(self, temp_mapping_file):
         """Test adding occurrence with invalid data."""
@@ -189,13 +188,13 @@ class TestMappingManager:
             "issue_title": "One-off Meeting",
             "start_time": "2025-04-24T14:00:00Z",
             "duration": 90,
-            "meeting_id": "123456789"  # Required for one-off calls
+            "meeting_id": "123456789"
         }
-        manager.add_occurrence("one-off", occurrence_data)
+        manager.add_occurrence("one-off-1465", occurrence_data)
 
         # Update occurrence
         update_data = {"discourse_topic_id": 23502}
-        success = manager.update_occurrence("one-off", 1465, update_data)
+        success = manager.update_occurrence("one-off-1465", 1465, update_data)
         assert success is True
 
         # Verify update
@@ -238,13 +237,13 @@ class TestMappingManager:
             "issue_title": "One-off Meeting",
             "start_time": "2025-04-24T14:00:00Z",
             "duration": 90,
-            "meeting_id": "123456789"  # Required for one-off calls
+            "meeting_id": "123456789"
         }
-        manager.add_occurrence("one-off", occurrence_data)
+        manager.add_occurrence("one-off-1465", occurrence_data)
 
         result = manager.find_occurrence(1465)
         assert result is not None
-        assert result["call_series"] == "one-off"
+        assert result["call_series"] == "one-off-1465"
         assert result["occurrence"]["issue_number"] == 1465
 
     def test_find_occurrence_not_found(self, temp_mapping_file):


### PR DESCRIPTION
refactor + couple bug fixes:
- change the data structure of one-off calls to more closely resemble recurring calls, removing many logic forks throughout
- restrict meeting_id's to the root level; no occurrence-level overrides
- fix resource upload bug that referenced old data model