### PR TITLE
Update the Protocol Upgrade Process document

### DIFF
--- a/processes/protocol-upgrade.md
+++ b/processes/protocol-upgrade.md
@@ -28,7 +28,7 @@ Ethereum has regular protocol upgrades that introduce performance, security and 
 - Devnets are expected to experience issues, are short lived, and a new one should be launched when relevant. Given their short lived nature, they are considered out of scope of this process.
 
 ### Testnets
-- There must be a 14 day period between client releases being ready, and the first testnet going live.
+- There must be at least 14 days between client releases being ready, and the first testnet going live. If the first testnet being upgraded is planned to be shut down after the upgrade, this delay can be reduced to 7 days. 
     - This is to provide time for internal security reviews, inclusion of upgrade specific code in the bug bounty program, and potential external security reviews.
 
 ### Mainnet


### PR DESCRIPTION
Following the conversation on [ACDE#219](https://github.com/ethereum/pm/issues/1687) about upgrade timing, I went back to look at the conversations we had when adopting this process document. The testnet timeline proposed were [somewhat contentious](https://www.youtube.com/live/0eVoE_isGBk?feature=shared&t=631) and we never finalized our discussion on ACD about agreeing to them. The latest time it explicitly came up was [here](https://www.youtube.com/live/dkIQxIHX56E?feature=shared&t=396). 

This PR proposes timelines that are more in line with what we've historically done and which — from my conversation with L2s, LSTs and infrastructure providers — should be acceptable by the community. In short: 

* Don't couple testnet and mainnet forks in client releases (multiple testnet forks in one release is OK)
* Minimum 14 days between client releases and the **first testnet** fork
* Minimum 10 days (ideally ~2 weeks) between each testnet fork
* Minimum 30 days between client releases and the **mainnet** fork

For Fusaka, one compromise solution could be to have two weeks between the releases and Holesky (soon to be [shut down](https://blog.ethereum.org/2025/09/01/holesky-shutdown-announcement)), and then two weeks until Sepolia, the first "real" testnet. 