### PR TITLE
Test forkcast dispatch token

### DIFF
--- a/.github/workflows/test-forkcast-dispatch.yml
+++ b/.github/workflows/test-forkcast-dispatch.yml
@@ -1,0 +1,20 @@
+name: "Test Forkcast Dispatch Token"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test Forkcast dispatch token
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.FORKCAST_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'ethereum',
+              repo: 'forkcast',
+              event_type: 'pm-assets-updated'
+            });
+            console.log('Dispatch sent successfully!');


### PR DESCRIPTION
## Summary
- Adds a temporary `workflow_dispatch` workflow to test whether the `FORKCAST_DISPATCH_TOKEN` secret can successfully send a repository dispatch to `ethereum/forkcast`.
- Delete this workflow and branch after confirming the token works.

## Test plan
- Merge this PR (or run from the branch)
- Go to Actions → "Test Forkcast Dispatch Token" → Run workflow
- Verify the step succeeds without a 401 error