### PR TITLE
ci: add PR validation for ACDbot dependencies

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## Summary
- Adds a new `pr-validation.yml` workflow that runs on PRs touching `.github/ACDbot/**`
- Installs dependencies and runs pytest to catch breakages before merge
- This would have caught the requests 2.33.0 / Python 3.9 incompatibility from dependabot

## Test plan
- [x] Verify this PR's CI run **fails** (intentionally using Python 3.9 + requests==2.33.0 to reproduce the bug)
- [x] Fix Python version + requests version, push again
- [x] Verify CI run **passes**

🤖 Generated with [Claude Code](https://claude.com/claude-code)