### PR TITLE
Upgrade GitHub Actions to latest versions (Node.js 24)

### DIFF
--- a/.github/workflows/cancel-unmapped-meetings.yml
+++ b/.github/workflows/cancel-unmapped-meetings.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/close-stale-meetings.yml
+++ b/.github/workflows/close-stale-meetings.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -9,9 +9,9 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install dependencies

--- a/.github/workflows/meeting-asset-pipeline.yml
+++ b/.github/workflows/meeting-asset-pipeline.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -194,7 +194,7 @@ jobs:
 
       - name: Notify Forkcast
         if: steps.commit.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.FORKCAST_DISPATCH_TOKEN }}
           script: |

--- a/.github/workflows/protocol-call-workflow.yml
+++ b/.github/workflows/protocol-call-workflow.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Check Organization Membership
         id: check_org_membership
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.ORG_READ_TOKEN }}
           script: |
@@ -180,10 +180,10 @@ jobs:
     if: needs.check_membership.outputs.is_member == 'true'
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/regex-labeler.yml
+++ b/.github/workflows/regex-labeler.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Run labeler
         uses: github/issue-labeler@v3.4
         with:

--- a/.github/workflows/rss-feed-generator.yml
+++ b/.github/workflows/rss-feed-generator.yml
@@ -20,10 +20,10 @@ jobs:
     
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/upcoming-calls.yml
+++ b/.github/workflows/upcoming-calls.yml
@@ -9,9 +9,9 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Install dependencies

--- a/.github/workflows/update-acd-table.yml
+++ b/.github/workflows/update-acd-table.yml
@@ -14,10 +14,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       

--- a/.github/workflows/update-active-breakouts.yml
+++ b/.github/workflows/update-active-breakouts.yml
@@ -13,10 +13,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       


### PR DESCRIPTION
## Summary
- Upgrades `actions/checkout` from v3/v4 → **v6**
- Upgrades `actions/setup-python` from v4/v5 → **v6**
- Upgrades `actions/github-script` from v6/v7 → **v8**

All 10 workflow files updated. These are drop-in replacements — the major version bumps are Node.js runtime upgrades (20 → 24) with no API breaking changes.

Resolves the Node.js 20 deprecation warnings before GitHub's June 2, 2026 enforcement date.

## Test plan
Tested on fork ([dionysuzx/pm](https://github.com/dionysuzx/pm/actions?query=branch%3Afix%2Fupgrade-actions-node24)):

- [x] Verify `protocol-call-workflow` runs (check_membership + handle_protocol_call jobs) — uses same `checkout@v6`, `setup-python@v6`, `github-script@v8` validated below; no `workflow_dispatch` trigger to test directly
- [x] Verify `meeting-asset-pipeline` runs (checkout, setup-python, github-script steps) — [passed](https://github.com/dionysuzx/pm/actions/runs/23872316364)
- [x] Spot-check one scheduled workflow (e.g. `discord-notify` or `upcoming-calls`) — both [discord-notify](https://github.com/dionysuzx/pm/actions/runs/23872317151) and [upcoming-calls](https://github.com/dionysuzx/pm/actions/runs/23872315578) passed

All failures were expected missing-secrets errors on the fork (Zoom, YouTube, etc.) — no issues from the action version upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)