### PR TITLE
acdbot: prevent BAL transcript corruption

### DIFF
--- a/.github/ACDbot/artifacts/acdc/2026-04-16_177/tldr.json
+++ b/.github/ACDbot/artifacts/acdc/2026-04-16_177/tldr.json
@@ -8,7 +8,7 @@
       },
       {
         "timestamp": "00:47:00",
-        "highlight": "ePBS DevNet 2 cancelled; merging ePBS and FOCIL for DevNet 0"
+        "highlight": "ePBS DevNet 2 cancelled; merging ePBS and BAL for DevNet 0"
       },
       {
         "timestamp": "01:06:40",
@@ -70,7 +70,7 @@
     },
     {
       "timestamp": "00:48:30",
-      "decision": "Skip ePBS DevNet 2; launch Glamsterdam DevNet 0 with merged ePBS+FOCIL"
+      "decision": "Skip ePBS DevNet 2; launch Glamsterdam DevNet 0 with merged ePBS+BAL"
     },
     {
       "timestamp": "00:53:50",

--- a/.github/ACDbot/artifacts/acdc/2026-04-16_177/transcript_changelog.tsv
+++ b/.github/ACDbot/artifacts/acdc/2026-04-16_177/transcript_changelog.tsv
@@ -3,5 +3,4 @@ Glenster Dam	Glamsterdam	high
 DevNets	devnets	high
 Hagoda	Hegota	high
 EPBS	ePBS	high
-BAL	FOCIL	medium
 Nethermine	Nethermind	high

--- a/.github/ACDbot/artifacts/acdc/2026-04-16_177/transcript_corrected.vtt
+++ b/.github/ACDbot/artifacts/acdc/2026-04-16_177/transcript_corrected.vtt
@@ -38,7 +38,7 @@ stokes: You know, in the short term, looking at Glamsterdam and moving forward w
 
 10
 00:11:28.580 --> 00:11:35.449
-stokes: And if there's time, we'll have an update on some of the FOCIL work.
+stokes: And if there's time, we'll have an update on some of the BAL work.
 
 11
 00:11:35.950 --> 00:11:38.300
@@ -754,7 +754,7 @@ stokes: I forget what these comments are. Yeah, okay. So I think from here, I mi
 
 189
 00:36:25.120 --> 00:36:32.469
-stokes: There's FOCIL DevNet 4, eBPS DevNet 2, that's gonna reflect some of the changes we were just discussing.
+stokes: There's BAL DevNet 4, eBPS DevNet 2, that's gonna reflect some of the changes we were just discussing.
 
 190
 00:36:32.760 --> 00:36:36.760
@@ -998,7 +998,7 @@ terence: are minimally touched by 5094.
 
 250
 00:42:57.480 --> 00:43:05.029
-stokes: Yeah, and so we're not worried about, like, some FOCIL bug on the EL causing issues with the EPPS state transition, and…
+stokes: Yeah, and so we're not worried about, like, some BAL bug on the EL causing issues with the EPPS state transition, and…
 
 251
 00:43:05.180 --> 00:43:06.380
@@ -1662,7 +1662,7 @@ stokes: Yup.
 
 416
 00:59:40.570 --> 00:59:47.610
-stokes: Okay, cool. And then, yeah, circling back to BOTUS, I'm assuming you might have a question about the FOCIL stuff?
+stokes: Okay, cool. And then, yeah, circling back to BOTUS, I'm assuming you might have a question about the BAL stuff?
 
 417
 00:59:48.010 --> 00:59:56.029
@@ -2443,4 +2443,3 @@ Potuz: Bye-bye.
 611
 01:27:48.450 --> 01:27:49.140
 Justin Traglia: Hi, everyone.
-

--- a/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
+++ b/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
@@ -34,6 +34,7 @@ acronyms:
   - ePBS: enshrined Proposer-Builder Separation
   - PeerDAS: Peer Data Availability Sampling
   - FOCIL: Fork-Choice Inclusion Lists
+  - BAL: Block Access List
   - SSZ: Simple Serialize
   - RLP: Recursive Length Prefix
   - MPT: Merkle Patricia Trie
@@ -68,6 +69,7 @@ orgs:
 technical_terms:
   - blob
   - beacon chain
+  - block access list
   - validator
   - attestation
   - proposer

--- a/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
+++ b/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
@@ -69,7 +69,6 @@ orgs:
 technical_terms:
   - blob
   - beacon chain
-  - block access list
   - validator
   - attestation
   - proposer

--- a/.github/ACDbot/scripts/asset_pipeline/generate_changelog.py
+++ b/.github/ACDbot/scripts/asset_pipeline/generate_changelog.py
@@ -24,7 +24,7 @@ Identify misspelled Ethereum-specific terms in this WebVTT transcript that shoul
 2. Terms must be safe for global find/replace (no common words that could cause false positives)
 3. Focus on proper nouns, protocol names, technical terms from the vocabulary reference
 4. Only correct obvious transcription errors where context supports the correction
-6. When uncertain, leave unchanged
+5. When uncertain, leave unchanged
 
 ## Examples of GOOD corrections (specific terms):
 - Nethermine → Nethermind

--- a/.github/ACDbot/scripts/asset_pipeline/generate_changelog.py
+++ b/.github/ACDbot/scripts/asset_pipeline/generate_changelog.py
@@ -24,9 +24,8 @@ Identify misspelled Ethereum-specific terms in this WebVTT transcript that shoul
 2. Terms must be safe for global find/replace (no common words that could cause false positives)
 3. Focus on proper nouns, protocol names, technical terms from the vocabulary reference
 4. Only correct obvious transcription errors where context supports the correction
-5. Never replace one valid Ethereum acronym or term with another valid Ethereum acronym or term unless the transcript makes the intended correction explicit
-6. Short uppercase tokens (2-5 letters) are especially risky. If they already look like a plausible acronym, leave them unchanged unless the correction is an obvious casing or spacing fix from the vocabulary
-7. When uncertain, leave unchanged
+5. Do not rewrite plausible Ethereum acronyms or terms into different canonical terms; only fix obvious casing, spacing, or unmistakable transcription errors
+6. When uncertain, leave unchanged
 
 ## Examples of GOOD corrections (specific terms):
 - Nethermine → Nethermind
@@ -38,7 +37,6 @@ Identify misspelled Ethereum-specific terms in this WebVTT transcript that shoul
 - Full sentences or long phrases
 - Common words like "the", "from", "and"
 - Phrases with punctuation that may not match exactly
-- Replacing one valid acronym with another (for example: BAL → FOCIL)
 
 ## Output Format
 Return ONLY a TSV (tab-separated) with these columns, no markdown formatting:

--- a/.github/ACDbot/scripts/asset_pipeline/generate_changelog.py
+++ b/.github/ACDbot/scripts/asset_pipeline/generate_changelog.py
@@ -24,7 +24,9 @@ Identify misspelled Ethereum-specific terms in this WebVTT transcript that shoul
 2. Terms must be safe for global find/replace (no common words that could cause false positives)
 3. Focus on proper nouns, protocol names, technical terms from the vocabulary reference
 4. Only correct obvious transcription errors where context supports the correction
-5. When uncertain, leave unchanged
+5. Never replace one valid Ethereum acronym or term with another valid Ethereum acronym or term unless the transcript makes the intended correction explicit
+6. Short uppercase tokens (2-5 letters) are especially risky. If they already look like a plausible acronym, leave them unchanged unless the correction is an obvious casing or spacing fix from the vocabulary
+7. When uncertain, leave unchanged
 
 ## Examples of GOOD corrections (specific terms):
 - Nethermine → Nethermind
@@ -36,6 +38,7 @@ Identify misspelled Ethereum-specific terms in this WebVTT transcript that shoul
 - Full sentences or long phrases
 - Common words like "the", "from", "and"
 - Phrases with punctuation that may not match exactly
+- Replacing one valid acronym with another (for example: BAL → FOCIL)
 
 ## Output Format
 Return ONLY a TSV (tab-separated) with these columns, no markdown formatting:

--- a/.github/ACDbot/scripts/asset_pipeline/generate_changelog.py
+++ b/.github/ACDbot/scripts/asset_pipeline/generate_changelog.py
@@ -24,7 +24,6 @@ Identify misspelled Ethereum-specific terms in this WebVTT transcript that shoul
 2. Terms must be safe for global find/replace (no common words that could cause false positives)
 3. Focus on proper nouns, protocol names, technical terms from the vocabulary reference
 4. Only correct obvious transcription errors where context supports the correction
-5. Do not rewrite plausible Ethereum acronyms or terms into different canonical terms; only fix obvious casing, spacing, or unmistakable transcription errors
 6. When uncertain, leave unchanged
 
 ## Examples of GOOD corrections (specific terms):


### PR DESCRIPTION
## Summary
ACDbot generated a bad changelog correction for ACDC 177 that rewrote `BAL` to `FOCIL`, and that polluted the corrected transcript and TLDR.

## Fix
- add `BAL` to the Ethereum vocabulary reference
- tighten changelog generation so one valid acronym is not rewritten into another
- repair the affected ACDC 177 changelog, corrected transcript, and TLDR