### PR TITLE
acdbot: correct BAL acronym definition

### DIFF
--- a/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
+++ b/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
@@ -34,7 +34,7 @@ acronyms:
   - ePBS: enshrined Proposer-Builder Separation
   - PeerDAS: Peer Data Availability Sampling
   - FOCIL: Fork-Choice Inclusion Lists
-  - BAL: Block Access List
+  - BAL: Block-Level Access Lists
   - SSZ: Simple Serialize
   - RLP: Recursive Length Prefix
   - MPT: Merkle Patricia Trie


### PR DESCRIPTION
Addresses review comment on #2025: https://github.com/ethereum/pm/pull/2025/files#r3097590260

Expands BAL to "Block-Level Access Lists" in the acdbot vocabulary file.