### PR TITLE
Fix execution-specs EIP Authors Manual links

### DIFF
--- a/processes/2025_championing_an_EIP.md
+++ b/processes/2025_championing_an_EIP.md
@@ -48,7 +48,7 @@ Once the EIP is published, you can make it much easier for the community to eval
 
 - Implement your changes in the [execution-specs](https://github.com/ethereum/execution-specs) (EELS)
   - EIP authors are encouraged to attempt the implementation on their own. Once a PR is created, EELS maintainers regularly step in to provide feedback or polish the implementation.
-  - Reference the [EIP Author's Manual](https://github.com/ethereum/execution-specs/blob/master/EIP_AUTHORS_MANUAL.md).
+  - Reference the [EIP Author's Manual](https://github.com/ethereum/execution-specs/blob/6333758e404889469abfed22a3028fa0eb459520/docs/specs/adding_a_new_eip.md).
 - Generate client tests via the [execution-spec-tests](https://github.com/ethereum/execution-spec-tests) (EEST)
   - This step is frequently performed or augmented by EEST maintainers, but EIP authors are encouraged to make an attempt.
   - Reference the [EEST docs](https://ethereum.github.io/execution-spec-tests/getting_started/quick_start/).

--- a/processes/2026_championing_an_EIP.md
+++ b/processes/2026_championing_an_EIP.md
@@ -64,11 +64,12 @@ It is strongly encouraged to implement the EIP's protocol changes in the relevan
 <details>
 <summary>If your EIP impacts the Execution Layer:</summary>
 
-- Implement your changes in the [execution-specs](https://github.com/ethereum/execution-specs) (EELS)
+- Implement your changes in [execution-specs](https://github.com/ethereum/execution-specs) (EELS)
+  - Check the [docs](https://steel.ethereum.foundation/docs/) for help getting started.
   - EIP authors are encouraged to attempt the implementation on their own. Once a PR is created, EELS maintainers regularly step in to provide feedback or polish the implementation.
-  - Reference the [EIP Author's Manual](https://github.com/ethereum/execution-specs/blob/master/EIP_AUTHORS_MANUAL.md).
-  - Add test cases in an appropriate sub-folder of [`tests/unscheduled/`](https://github.com/ethereum/execution-specs/tree/b3543e94d12288e994fc1adea606c1a417db4a9f/tests/unscheduled). EELS maintainers will help with coverage, but simple tests can help you to verify your implementation.
-- For any help you may need, reach out to the [STEEL Team](https://steel.ethereum.foundation/) in the [Eth R&D Discord](https://discord.gg/EVTQ9crVgQ), `#el-testing` channel.
+  - Reference the [EIP Author's Manual](https://github.com/ethereum/execution-specs/blob/6333758e404889469abfed22a3028fa0eb459520/docs/specs/adding_a_new_eip.md).
+  - Add test cases in an appropriate sub-folder of [`tests/unscheduled/`](https://github.com/ethereum/execution-specs/tree/6333758e404889469abfed22a3028fa0eb459520/tests/unscheduled). EELS maintainers will help with coverage, but simple tests can help you to verify your implementation.
+- For any help you may need, reach out to the [STEEL Team](https://steel.ethereum.foundation/team) in the [Eth R&D Discord](https://discord.gg/EVTQ9crVgQ), `#el-testing` channel.
 
 </details>
 


### PR DESCRIPTION
The EIP Author's Manual was moved from `EIP_AUTHORS_MANUAL.md` in the repo root to the HTML docs in https://github.com/ethereum/execution-specs/pull/2677 - this PR fixes up those links.

You can browse it here, https://steel.ethereum.foundation/docs/execution-specs/forks/amsterdam/specs/adding_a_new_eip/

But...This PR doesn't link to this HTML page as we only publish docs for ephemeral branches at the mo as "forks/amsterdam" (the current default branch in dexecution-specs) will get deleted in due course and its docs with it. mainnet docs version coming sooon.

cc @nixorokish 