### PR TITLE
acdbot: prevent lean client name corruption

### DIFF
--- a/.github/ACDbot/artifacts/pqinterop/2026-05-06_038/tldr.json
+++ b/.github/ACDbot/artifacts/pqinterop/2026-05-06_038/tldr.json
@@ -40,7 +40,7 @@
     "client_progress": [
       {
         "timestamp": "00:16:46",
-        "highlight": "Zeem optimizing aggregator performance and payload re-aggregation API"
+        "highlight": "Zeam optimizing aggregator performance and payload re-aggregation API"
       },
       {
         "timestamp": "00:18:25",
@@ -52,7 +52,7 @@
       },
       {
         "timestamp": "00:52:01",
-        "highlight": "ETH Lambda added LibP2P Identify Protocol support for Zeem interop"
+        "highlight": "Ethlambda added LibP2P Identify Protocol support for Zeam interop"
       }
     ],
     "devnet_5_scope": [

--- a/.github/ACDbot/artifacts/pqinterop/2026-05-06_038/transcript_changelog.tsv
+++ b/.github/ACDbot/artifacts/pqinterop/2026-05-06_038/transcript_changelog.tsv
@@ -1,6 +1,6 @@
 original	corrected	confidence
-Zim	Zeem	high
-NLEAN	QLEAN	high
+Zim	Zeam	high
+NLEAN	Qlean	high
 DevNet	devnet	high
 DevNets	devnets	high
 DevNet0	devnet0	high

--- a/.github/ACDbot/artifacts/pqinterop/2026-05-06_038/transcript_corrected.vtt
+++ b/.github/ACDbot/artifacts/pqinterop/2026-05-06_038/transcript_corrected.vtt
@@ -26,7 +26,7 @@ Thomas Coratger: So… Let's get started. Welcome to Post Quantum interrupt numb
 
 7
 00:16:10.550 --> 00:16:27.009
-Thomas Coratger: So, first, so we have different topics on the agenda. We will discuss, I think, mainly a devnet 5 proposal, but first, let us start with client updates. So, Zeem first.
+Thomas Coratger: So, first, so we have different topics on the agenda. We will discuss, I think, mainly a devnet 5 proposal, but first, let us start with client updates. So, Zeam first.
 
 8
 00:16:29.040 --> 00:16:30.030
@@ -214,7 +214,7 @@ Derek Sorken: it's a little bit difficult to say, okay, which client's doing wha
 
 54
 00:21:49.250 --> 00:21:55.569
-Derek Sorken: Okay, now we can see, okay, given client, okay, now it's Gein, or now it's Enlina, or whatnot.
+Derek Sorken: Okay, now we can see, okay, given client, okay, now it's Gean, or now it's Enlina, or whatnot.
 
 55
 00:21:55.890 --> 00:22:01.690
@@ -262,7 +262,7 @@ Derek Sorken: Or… If we want, we can see, of course.
 
 66
 00:22:53.950 --> 00:22:56.850
-Derek Sorken: In the case of, like, we have QLing here, I think it's just the,
+Derek Sorken: In the case of, like, we have Qlean here, I think it's just the,
 
 67
 00:22:57.140 --> 00:23:07.599
@@ -302,7 +302,7 @@ Derek Sorken: For client interop, it makes things way easier to see, you know, w
 
 76
 00:23:50.590 --> 00:24:03.709
-Derek Sorken: And so, I might add a little legend here, but, for example, we can see ETH lambda majority, and so two ETH lambda nodes, and say one key node works, and, like, one end lead node doesn't work, and if we want to go from the minority side instead, we can say, okay.
+Derek Sorken: And so, I might add a little legend here, but, for example, we can see Ethlambda majority, and so two Ethlambda nodes, and say one key node works, and, like, one end lead node doesn't work, and if we want to go from the minority side instead, we can say, okay.
 
 77
 00:24:03.860 --> 00:24:04.590
@@ -310,7 +310,7 @@ Derek Sorken: You know
 
 78
 00:24:04.980 --> 00:24:12.369
-Derek Sorken: when there's only one Zeeam node, but then there's two QLEAN nodes, things are failing, and of course, we can, again, navigate to see
+Derek Sorken: when there's only one Zeam node, but then there's two Qlean nodes, things are failing, and of course, we can, again, navigate to see
 
 79
 00:24:12.820 --> 00:24:16.219
@@ -838,15 +838,15 @@ Shariq Naiyer: let's just ensure that we don't have a lean start, lean start des
 
 210
 00:46:46.470 --> 00:47:03.400
-Shariq Naiyer: So you could also say, oh, I want one… one of Zeem, two of Zeem, so I could run two Zeem, I could run them in two subnets. So there's a lot of… there's a lot of, like, playing around, but let's just run Ream, Zeem, and ReamZeem eats Lambda, one subnet.
+Shariq Naiyer: So you could also say, oh, I want one… one of Zeam, two of Zeam, so I could run two Zeam, I could run them in two subnets. So there's a lot of… there's a lot of, like, playing around, but let's just run Ream, Zeam, and Ethlambda, one subnet.
 
 211
 00:47:03.760 --> 00:47:14.380
-Shariq Naiyer: So, this will now start a run with Reem, Zeem, and ETHLambda, and would save these logs in these timestamp format, as well as the latest logs will be in the latest folder.
+Shariq Naiyer: So, this will now start a run with Ream, Zeam, and Ethlambda, and would save these logs in these timestamp format, as well as the latest logs will be in the latest folder.
 
 212
 00:47:14.930 --> 00:47:30.970
-Shariq Naiyer: Now, I was trying to run all the clients at once, I was trying to run ETHLambda, Lantern, QLEAN, Dream, Zeem, as much as my, my, home piece, personal laptop would allow. But what I was finding is, like, it's hard to debug there, it's hard to figure out what's going wrong, and…
+Shariq Naiyer: Now, I was trying to run all the clients at once, I was trying to run Ethlambda, Lantern, Qlean, Ream, Zeam, as much as my, my, home piece, personal laptop would allow. But what I was finding is, like, it's hard to debug there, it's hard to figure out what's going wrong, and…
 
 213
 00:47:31.210 --> 00:47:36.959
@@ -854,11 +854,11 @@ Shariq Naiyer: So, here's what I started doing. I started running smaller subnet
 
 214
 00:47:37.430 --> 00:47:54.490
-Shariq Naiyer: One thing to note is, when running in one subnet, a lot of clients are pretty stable. However, when running in two subnets, like, clients start to break quite easily. So, what I've started with first is running Ream, Zeeam, and ETH Lambda. This tool is open source, and it's available on,
+Shariq Naiyer: One thing to note is, when running in one subnet, a lot of clients are pretty stable. However, when running in two subnets, like, clients start to break quite easily. So, what I've started with first is running Ream, Zeam, and Ethlambda. This tool is open source, and it's available on,
 
 215
 00:47:54.490 --> 00:48:19.279
-Shariq Naiyer: like, Ream Labs slash lean start, so anyone can run these devnets and start running them. You could also go to Clients, and you could change what Docker image you're using, so you could test with your local Docker image and stuff. So, what I've started doing is I'm running 3 clients right now, Rheem, Zeeam, and Ethlambda, figuring out what the issues are. If it's small enough, I'll just make it, test it on a local build, and push a PR to the client, and…
+Shariq Naiyer: like, Ream Labs slash lean start, so anyone can run these devnets and start running them. You could also go to Clients, and you could change what Docker image you're using, so you could test with your local Docker image and stuff. So, what I've started doing is I'm running 3 clients right now, Ream, Zeam, and Ethlambda, figuring out what the issues are. If it's small enough, I'll just make it, test it on a local build, and push a PR to the client, and…
 
 216
 00:48:19.280 --> 00:48:23.019
@@ -874,7 +874,7 @@ Shariq Naiyer: with 3 clients with, like, these less amount of logs, it's easier
 
 219
 00:48:44.350 --> 00:48:54.959
-Shariq Naiyer: So I'm starting with Rheem, Zem, ETHLambda. Once this is stable enough, stable, I'm gonna see… currently, what I'm finding is ETH Lambda does not reach finalization, while Rheem and Zeem
+Shariq Naiyer: So I'm starting with Ream, Zeam, Ethlambda. Once this is stable enough, stable, I'm gonna see… currently, what I'm finding is Ethlambda does not reach finalization, while Ream and Zeam
 
 220
 00:48:55.120 --> 00:49:03.639
@@ -882,11 +882,11 @@ Shariq Naiyer: comfortably reach finalization, but the issue might not be any…
 
 221
 00:49:07.180 --> 00:49:14.240
-Shariq Naiyer: So, yeah, so… Zem reached finalization, both ZEM, reached finalization, both,
+Shariq Naiyer: So, yeah, so… Zeam reached finalization, both Zeam, reached finalization, both,
 
 222
 00:49:14.410 --> 00:49:34.549
-Shariq Naiyer: lean reach finalization, but ETLambda did not, did not catch up. Now, one thing to note is this is likely not a problem in ETLambda. Like, this may be a problem in one of the three clients, but it's an interop problem. Clients are not interoping with each other. I'm going to figure out the problem here, and see the step forward. Then, I'm going to integrate Grandine.
+Shariq Naiyer: lean reach finalization, but Ethlambda did not, did not catch up. Now, one thing to note is this is likely not a problem in Ethlambda. Like, this may be a problem in one of the three clients, but it's an interop problem. Clients are not interoping with each other. I'm going to figure out the problem here, and see the step forward. Then, I'm going to integrate Grandine.
 
 223
 00:49:34.550 --> 00:49:57.059
@@ -1058,7 +1058,7 @@ Thomas Coratger: Great, Guin.
 
 265
 00:54:43.890 --> 00:54:56.759
-Shaaibu Suleiman | gean: Yeah, hello, hello. Yeah, so, on our site, we've been, running, devnet4, basically, Jim, with a couple of other clients, basically, doing some testing.
+Shaaibu Suleiman | gean: Yeah, hello, hello. Yeah, so, on our site, we've been, running, devnet4, basically, Gean, with a couple of other clients, basically, doing some testing.
 
 266
 00:54:56.910 --> 00:55:01.629

--- a/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
+++ b/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
@@ -14,6 +14,16 @@ clients:
     - Teku
     - Nimbus
     - Grandine
+  lean:
+    - Ream
+    - Zeam
+    - Qlean
+    - Qlean-mini
+    - Lantern
+    - Lighthouse
+    - Ethlambda
+    - Gean
+    - Peam
 
 upgrades:
   past:
@@ -115,3 +125,15 @@ error_patterns:
   - Glamstronam: Glamsterdam
   - SSC: SSZ
   - DevNet: devnet
+  - Zeeam: Zeam
+  - Zeem: Zeam
+  - ZEM: Zeam
+  - Zem: Zeam
+  - Gein: Gean
+  - QLing: Qlean
+  - QLEAN: Qlean
+  - Rheem: Ream
+  - Reem: Ream
+  - ETHLambda: Ethlambda
+  - ETH Lambda: Ethlambda
+  - ETH lambda: Ethlambda


### PR DESCRIPTION
## Summary

- Add lean Ethereum clients to `ethereum_vocab.yaml` under a new `clients.lean` section: Ream, Zeam, Qlean, Qlean-mini, Lantern, Lighthouse, Ethlambda, Gean, Peam.
- Register error patterns so the changelog stage catches future transcription variants automatically: Zeem/Zeeam/Zem/ZEM → Zeam, Gein → Gean, QLing/QLEAN → Qlean, Rheem/Reem → Ream, ETHLambda/ETH Lambda/ETH lambda → Ethlambda. Held back unsafe globals (`Jim → Gean`, `Dream → Ream`) — they were applied scoped in the PQI 038 artifact only.
- Fix the corrupted PQI 038 artifacts in place: transcript, TLDR, and changelog all retargeted to the canonical forms. Mirrors ethereum/forkcast#232.

## Test plan

- [ ] Confirm `ethereum_vocab.yaml` parses cleanly (it's loaded by both `generate_changelog.py` and `generate_summary.py`)
- [ ] Eyeball PQI 038 artifacts for any remaining variant the patterns missed
- [ ] On the next PQI call run, verify the new vocab entries propagate into the LLM prompt