### PR TITLE
acdbot: prevent bal-devnet/glamsterdam-devnet corruption

### DIFF
--- a/.github/ACDbot/artifacts/acde/2026-05-07_236/tldr.json
+++ b/.github/ACDbot/artifacts/acde/2026-05-07_236/tldr.json
@@ -4,7 +4,7 @@
     "fork_status_and_schedule": [
       {
         "timestamp": "00:07:15",
-        "highlight": "Glamsterdam devnets 0-3 launched; devnet 2 added EIP-8061"
+        "highlight": "Glamsterdam devnets 0-3 launched; glamsterdam-devnet-2 added EIP-8061"
       },
       {
         "timestamp": "00:09:24",
@@ -14,15 +14,15 @@
     "testing_progress": [
       {
         "timestamp": "00:11:00",
-        "highlight": "Ball devnet 6 stable with Lighthouse/Lodestar; Glamsterdam devnet 3 running"
+        "highlight": "bal-devnet-6 stable with Lighthouse/Lodestar; glamsterdam-devnet-3 running"
       },
       {
         "timestamp": "00:11:38",
-        "highlight": "Ball devnet 7 planned for next week with 8037 fixes"
+        "highlight": "bal-devnet-7 planned for next week with 8037 fixes"
       },
       {
         "timestamp": "00:14:27",
-        "highlight": "Optimization merges needed to Ball devnet 3 until devnet 7 stable"
+        "highlight": "Optimization merges needed to bal-devnet-3 until bal-devnet-7 stable"
       }
     ],
     "eip_proposals": [
@@ -110,7 +110,7 @@
   "targets": [
     {
       "timestamp": "00:11:48",
-      "target": "Ball devnet 7 launch - next week"
+      "target": "bal-devnet-7 launch - next week"
     }
   ]
 }

--- a/.github/ACDbot/artifacts/acde/2026-05-07_236/transcript_corrected.vtt
+++ b/.github/ACDbot/artifacts/acde/2026-05-07_236/transcript_corrected.vtt
@@ -78,7 +78,7 @@ nixo: Yep.
 
 20
 00:08:09.540 --> 00:08:24.099
-Barnabas: Yeah, so we started out, with answering devnet 0, on the second day of in the interop. We basically included, all the, Ball devnet 5 changes and, ePBS.
+Barnabas: Yeah, so we started out, with answering devnet 0, on the second day of in the interop. We basically included, all the, bal-devnet-5 changes and, ePBS.
 
 21
 00:08:24.450 --> 00:08:29.280
@@ -138,7 +138,7 @@ Barnabas: We have, currently, Docker Access, Ball.net 6 up and running, with the
 
 35
 00:10:22.150 --> 00:10:29.270
-Barnabas: That has been quite stable, and we have Glamsterdam devnet 3, which is basically the same spec as Glamsterdam devnet 2.
+Barnabas: That has been quite stable, and we have glamsterdam-devnet-3, which is basically the same spec as glamsterdam-devnet-2.
 
 36
 00:10:30.880 --> 00:10:43.010
@@ -266,15 +266,15 @@ Maria Silva: working on Vol devnet 7 for next week, but at this point, we still 
 
 67
 00:14:45.440 --> 00:14:57.869
-Maria Silva: So, we are working on Ball devnet 7, with the fixes from 8037, and that should then, at some point next week, become our EL stable branch, but until then, for the clients that are
+Maria Silva: So, we are working on bal-devnet-7, with the fixes from 8037, and that should then, at some point next week, become our EL stable branch, but until then, for the clients that are
 
 68
 00:14:57.870 --> 00:15:08.150
-Maria Silva: working on the optimization still from last week, please merge them to Ball devnet3 so we can see the results on Benchmarker.
+Maria Silva: working on the optimization still from last week, please merge them to bal-devnet-3 so we can see the results on Benchmarker.
 
 69
 00:15:12.700 --> 00:15:21.950
-Maria Silva: Sorry, I think I'm… I may have missed some of the numbers there, but essentially, it's, like, merge optimizations to Paul devnet 3 until we have
+Maria Silva: Sorry, I think I'm… I may have missed some of the numbers there, but essentially, it's, like, merge optimizations to bal-devnet-3 until we have
 
 70
 00:15:22.270 --> 00:15:24.049

--- a/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
+++ b/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
@@ -137,3 +137,30 @@ error_patterns:
   - ETHLambda: Ethlambda
   - ETH Lambda: Ethlambda
   - ETH lambda: Ethlambda
+  - Ball devnet 0: bal-devnet-0
+  - Ball devnet 1: bal-devnet-1
+  - Ball devnet 2: bal-devnet-2
+  - Ball devnet 3: bal-devnet-3
+  - Ball devnet 4: bal-devnet-4
+  - Ball devnet 5: bal-devnet-5
+  - Ball devnet 6: bal-devnet-6
+  - Ball devnet 7: bal-devnet-7
+  - Ball devnet 8: bal-devnet-8
+  - Ball devnet 9: bal-devnet-9
+  - Ball devnet 10: bal-devnet-10
+  - Ball devnet3: bal-devnet-3
+  - Ball devnet4: bal-devnet-4
+  - Ball devnet5: bal-devnet-5
+  - Ball devnet6: bal-devnet-6
+  - Ball devnet7: bal-devnet-7
+  - Glamsterdam devnet 0: glamsterdam-devnet-0
+  - Glamsterdam devnet 1: glamsterdam-devnet-1
+  - Glamsterdam devnet 2: glamsterdam-devnet-2
+  - Glamsterdam devnet 3: glamsterdam-devnet-3
+  - Glamsterdam devnet 4: glamsterdam-devnet-4
+  - Glamsterdam devnet 5: glamsterdam-devnet-5
+  - Glamsterdam devnet 6: glamsterdam-devnet-6
+  - Glamsterdam devnet 7: glamsterdam-devnet-7
+  - Glamsterdam devnet 8: glamsterdam-devnet-8
+  - Glamsterdam devnet 9: glamsterdam-devnet-9
+  - Glamsterdam devnet 10: glamsterdam-devnet-10

--- a/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
+++ b/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
@@ -69,6 +69,19 @@ infrastructure:
   - Flashbots
   - Kurtosis
 
+# Devnets are named <workstream>-devnet-<N> (lowercase, hyphenated, e.g.,
+# "bal-devnet-3", "glamsterdam-devnet-2"). When a transcript renders these as
+# "Ball devnet 5", "Paul devnet 3" (BAL mistranscribed), or
+# "Glamsterdam devnet 3", correct to the canonical form.
+devnets:
+  workstreams:
+    - bal           # Block-Level Access Lists
+    - glamsterdam
+    - epbs
+    - peerdas
+    - focil
+    - svalbard
+
 orgs:
   - Ethereum Foundation (EF)
   - Flashbots
@@ -137,30 +150,9 @@ error_patterns:
   - ETHLambda: Ethlambda
   - ETH Lambda: Ethlambda
   - ETH lambda: Ethlambda
-  - Ball devnet 0: bal-devnet-0
-  - Ball devnet 1: bal-devnet-1
-  - Ball devnet 2: bal-devnet-2
+  # Devnet anchor examples — see the `devnets` section below for the full convention.
+  # These show the LLM the pattern (lowercased prefix + hyphen + number); it will
+  # generalize to whatever numbers actually appear in a given transcript.
   - Ball devnet 3: bal-devnet-3
-  - Ball devnet 4: bal-devnet-4
-  - Ball devnet 5: bal-devnet-5
-  - Ball devnet 6: bal-devnet-6
-  - Ball devnet 7: bal-devnet-7
-  - Ball devnet 8: bal-devnet-8
-  - Ball devnet 9: bal-devnet-9
-  - Ball devnet 10: bal-devnet-10
-  - Ball devnet3: bal-devnet-3
-  - Ball devnet4: bal-devnet-4
-  - Ball devnet5: bal-devnet-5
-  - Ball devnet6: bal-devnet-6
-  - Ball devnet7: bal-devnet-7
-  - Glamsterdam devnet 0: glamsterdam-devnet-0
-  - Glamsterdam devnet 1: glamsterdam-devnet-1
+  - Paul devnet 3: bal-devnet-3
   - Glamsterdam devnet 2: glamsterdam-devnet-2
-  - Glamsterdam devnet 3: glamsterdam-devnet-3
-  - Glamsterdam devnet 4: glamsterdam-devnet-4
-  - Glamsterdam devnet 5: glamsterdam-devnet-5
-  - Glamsterdam devnet 6: glamsterdam-devnet-6
-  - Glamsterdam devnet 7: glamsterdam-devnet-7
-  - Glamsterdam devnet 8: glamsterdam-devnet-8
-  - Glamsterdam devnet 9: glamsterdam-devnet-9
-  - Glamsterdam devnet 10: glamsterdam-devnet-10

--- a/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
+++ b/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
@@ -69,19 +69,6 @@ infrastructure:
   - Flashbots
   - Kurtosis
 
-# Devnets are named <workstream>-devnet-<N> (lowercase, hyphenated, e.g.,
-# "bal-devnet-3", "glamsterdam-devnet-2"). When a transcript renders these as
-# "Ball devnet 5", "Paul devnet 3" (BAL mistranscribed), or
-# "Glamsterdam devnet 3", correct to the canonical form.
-devnets:
-  workstreams:
-    - bal           # Block-Level Access Lists
-    - glamsterdam
-    - epbs
-    - peerdas
-    - focil
-    - svalbard
-
 orgs:
   - Ethereum Foundation (EF)
   - Flashbots
@@ -150,9 +137,6 @@ error_patterns:
   - ETHLambda: Ethlambda
   - ETH Lambda: Ethlambda
   - ETH lambda: Ethlambda
-  # Devnet anchor examples — see the `devnets` section below for the full convention.
-  # These show the LLM the pattern (lowercased prefix + hyphen + number); it will
-  # generalize to whatever numbers actually appear in a given transcript.
   - Ball devnet 3: bal-devnet-3
   - Paul devnet 3: bal-devnet-3
   - Glamsterdam devnet 2: glamsterdam-devnet-2

--- a/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
+++ b/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
@@ -136,7 +136,6 @@ error_patterns:
   - Reem: Ream
   - ETHLambda: Ethlambda
   - ETH Lambda: Ethlambda
-  - ETH lambda: Ethlambda
   - Ball devnet 3: bal-devnet-3
   - Paul devnet 3: bal-devnet-3
   - Glamsterdam devnet 2: glamsterdam-devnet-2


### PR DESCRIPTION
## Summary
- Add error_patterns to `ethereum_vocab.yaml` so future ACD calls auto-correct `Ball devnet N` (and the `Ball devnetN` no-space variant) → `bal-devnet-N` and `Glamsterdam devnet N` → `glamsterdam-devnet-N`
- Mirror the corrected ACDE 236 transcript and TLDR (devnet name normalization)

### Companion PR
Forkcast-side artifact fixes + key_decisions corrections + EIP statusHistory updates: ethereum/forkcast#235

## Test plan
- [ ] Vocab YAML still parses (no syntax errors)
- [ ] PM artifact files for ACDE 236 byte-identical to Forkcast copies