### PR TITLE
acdbot: introduce p2p networking breakout

### DIFF
--- a/.github/ACDbot/call_series_config.yml
+++ b/.github/ACDbot/call_series_config.yml
@@ -305,6 +305,17 @@ call_series:
       display_zoom_link_in_invite: true
       external_meeting_link: false
 
+  p2pnetworking:
+    display_name: "P2P Networking"
+    youtube_playlist_id: null
+    discord_webhook_env: null
+    autopilot_defaults:
+      duration: 60
+      occurrence_rate: "bi-weekly"
+      need_youtube_streams: false
+      display_zoom_link_in_invite: true
+      external_meeting_link: false
+
   # Special: One-time calls (key becomes one-off-{issue_number} at runtime)
   # No autopilot_defaults - one-off calls require manual configuration
   one-off:

--- a/.github/ACDbot/call_series_config.yml
+++ b/.github/ACDbot/call_series_config.yml
@@ -307,7 +307,7 @@ call_series:
 
   p2pnetworking:
     display_name: "P2P Networking"
-    youtube_playlist_id: null
+    youtube_playlist_id: "PLJqWcTqh_zKHrBqj0fnITKvW5x7LYn2qG"
     discord_webhook_env: null
     autopilot_defaults:
       duration: 60

--- a/.github/ISSUE_TEMPLATE/protocol-call-form.yml
+++ b/.github/ISSUE_TEMPLATE/protocol-call-form.yml
@@ -54,6 +54,7 @@ body:
         - L1-zkEVM Breakout
         - L2 Interop Working Group
         - Native Account Abstraction
+        - P2P Networking
         - PQ Interop
         - PQ Transaction Signatures
         - Protocol Research

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -90,3 +90,6 @@ FCR:
 
 NativeAA:
  - "^(.*[Nn]ative [Aa]ccount [Aa]bstraction.*|.*NativeAA.*)"
+
+P2P:
+ - "^(.*P2P [Nn]etworking.*|.*P2PNetworking.*)"

--- a/.github/workflows/protocol-call-workflow.yml
+++ b/.github/workflows/protocol-call-workflow.yml
@@ -48,7 +48,7 @@ jobs:
               "samwilsn", "shemnon", "nixorokish", "dcrapis", "gabrocheleau",
               "joshdavislight", "nerolation", "jihoonsong", "bomanaps", "misilva73",
               "zsfelfoldi", "kevaundray", "jflo", "gcolvin", "asanso", "mkalinin",
-              "tcoratger"
+              "tcoratger", "kamilsa"
             ];
 
             console.log(`Checking membership for user: ${username}`);


### PR DESCRIPTION
## Summary

- Register a new **P2P Networking** breakout call series (facilitator: `@kamilsa`, bi-weekly, 60 min).
- Adds `kamilsa` to the trusted contributors list so the protocol-call workflow accepts their issues.
- Adds the `p2pnetworking` entry to `call_series_config.yml` with autopilot defaults matching other breakouts.
- Adds "P2P Networking" to the issue template dropdown and a `P2P` regex label to the labeler.

`youtube_playlist_id` is intentionally `null` — Protocol Support will populate after the first recording.