### PR TITLE
acdbot: add Fulu/Gloas CL codenames and transcription patterns

### DIFF
--- a/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
+++ b/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
@@ -33,8 +33,10 @@ upgrades:
     - Dencun
     - Pectra
     - Fusaka
+    - Fulu
   current:
     - Glamsterdam
+    - Gloas
   future:
     - Hegota
 
@@ -118,8 +120,10 @@ error_patterns:
   - e-o-f: EOF
   - pectra: Pectra
   - few soccer: Fusaka
+  - follow-up: Fulu
   - glam sterdam: Glamsterdam
   - golass: Gloas
+  - Glossas: Gloas
   - Hagota: Hegota
   - Clampstream: Glamsterdam
   - Glamstronam: Glamsterdam


### PR DESCRIPTION
## Summary
- Add `Fulu` (CL codename for Fusaka) and `Gloas` (CL codename for Glamsterdam) to the canonical upgrades lists.
- Add `follow-up: Fulu` error pattern — a natural speech-to-text mishear that was missed in a recent L1-zkEVM call transcript.
- Add `Glossas: Gloas` error pattern — closes the gap where the changelog stopped at the intermediate `Glow us → Glossas` correction instead of going to `Gloas`.

## Test plan
- [x] Diff matches existing style (lowercase key, canonical value, grouped near related fork entries)