### PR TITLE
acdbot: fix transcript artifacts + extend vocab

### DIFF
--- a/.github/ACDbot/artifacts/acdt/2026-05-18_080/tldr.json
+++ b/.github/ACDbot/artifacts/acdt/2026-05-18_080/tldr.json
@@ -8,7 +8,7 @@
       },
       {
         "timestamp": "00:27:22",
-        "highlight": "Erigon, Nethermind, Nimbus passing tests; Besu missing some tests; Geth branch not ready until mid-week"
+        "highlight": "ethrex, Nethermind, Nimbus passing tests; Besu missing some tests; Geth branch not ready until mid-week"
       },
       {
         "timestamp": "00:43:47",

--- a/.github/ACDbot/artifacts/acdt/2026-05-18_080/tldr.json
+++ b/.github/ACDbot/artifacts/acdt/2026-05-18_080/tldr.json
@@ -72,7 +72,7 @@
       "owner": "Felix / client teams"
     },
     {
-      "timestamp": "01:11:44",
+      "timestamp": "01:11:11",
       "action": "Decide between execution-apis PR #764 vs #793 (REST-SSZ Engine API)",
       "owner": "ACDE Thursday"
     }

--- a/.github/ACDbot/artifacts/acdt/2026-05-18_080/transcript_changelog.tsv
+++ b/.github/ACDbot/artifacts/acdt/2026-05-18_080/transcript_changelog.tsv
@@ -11,7 +11,7 @@ Gramstagram	Glamsterdam	high
 Grandstagram	Glamsterdam	high
 BaldevNet	BAL devnet	medium
 Bad DevNet	BAL devnet	medium
-Etherix	Erigon	medium
+Etherix	ethrex	medium
 Itrax	Erigon	medium
 Itrex	Erigon	medium
 Erdogan	Erigon	medium

--- a/.github/ACDbot/artifacts/acdt/2026-05-18_080/transcript_corrected.vtt
+++ b/.github/ACDbot/artifacts/acdt/2026-05-18_080/transcript_corrected.vtt
@@ -746,7 +746,7 @@ danceratopz: how they see the readiness for BAL devnet 7.
 
 187
 00:27:22.510 --> 00:27:38.540
-Stefan Starflinger: So, I've been doing some kurtosis testing with the clients that are passing all the, tests right now. So, that's, right now, Erigon, NetherMind, and Nimbus, and it seems to be going pretty well.
+Stefan Starflinger: So, I've been doing some kurtosis testing with the clients that are passing all the, tests right now. So, that's, right now, ethrex, NetherMind, and Nimbus, and it seems to be going pretty well.
 
 188
 00:27:38.540 --> 00:27:53.020

--- a/.github/ACDbot/artifacts/acdt/2026-05-18_080/transcript_corrected.vtt
+++ b/.github/ACDbot/artifacts/acdt/2026-05-18_080/transcript_corrected.vtt
@@ -186,7 +186,7 @@ Maria Silva: So I think there's, two things regarding benchmarking. So, I think 
 
 47
 00:11:13.910 --> 00:11:26.969
-Maria Silva: either… either way. So what this means is that once we have a definite where things are stable on implementation and we have all the repricings there, we do want to do a more…
+Maria Silva: either… either way. So what this means is that once we have a devnet where things are stable on implementation and we have all the repricings there, we do want to do a more…
 
 48
 00:11:27.090 --> 00:11:37.660
@@ -270,7 +270,7 @@ Stefan Starflinger: Glamsterdam, then Glamsterdam DevNets. I think it's a small 
 
 68
 00:14:05.200 --> 00:14:17.310
-Giulio: Yeah, exactly. But anyways, yeah, I think we can… I mean, yeah, so glamsterdam-devnet-5, yeah, whatever, glamsterdam-devnet-5, it's fine. Or the… yeah, the button at the 7th is supposed to come out today, right?
+Giulio: Yeah, exactly. But anyways, yeah, I think we can… I mean, yeah, so glamsterdam-devnet-5, yeah, whatever, glamsterdam-devnet-5, it's fine. Or the… yeah, the bal-devnet-7 is supposed to come out today, right?
 
 69
 00:14:18.620 --> 00:14:20.609
@@ -1278,7 +1278,7 @@ danceratopz: Thanks for sharing this, the notes, even.
 
 320
 00:42:31.900 --> 00:42:44.319
-Barnabas: Yeah, so basically, for the next DevNet iteration, we're gonna need to have a Glamsterdam-specific branch and a Ball DevNet-specific branch for Ball DevNet 7 and Glamsterdam DevNet 4.
+Barnabas: Yeah, so basically, for the next DevNet iteration, we're gonna need to have a Glamsterdam-specific branch and a bal-devnet-specific branch for bal-devnet-7 and Glamsterdam DevNet 4.
 
 321
 00:42:44.600 --> 00:42:45.530
@@ -1294,7 +1294,7 @@ Barnabas: Due to this new change interest in the engine?
 
 324
 00:42:56.940 --> 00:43:05.279
-danceratopz: So your shout… is this a shout-out to client teams to create Glamsterdam DevNet 4, instead of just using their Valve DevNet 7 branch? Exactly, yep.
+danceratopz: So your shout… is this a shout-out to client teams to create Glamsterdam DevNet 4, instead of just using their bal-devnet-7 branch? Exactly, yep.
 
 325
 00:43:06.060 --> 00:43:09.020
@@ -1322,7 +1322,7 @@ danceratopz: Yeah, okay, good, thanks.
 
 331
 00:43:38.930 --> 00:43:47.140
-danceratopz: Okay, so, Glamsterdam DevNet 4 will be targeted after Val DevNet 7,
+danceratopz: Okay, so, Glamsterdam DevNet 4 will be targeted after bal-devnet-7,
 
 332
 00:43:47.650 --> 00:43:50.609
@@ -1358,7 +1358,7 @@ danceratopz: I guess we'll handle that async as well.
 
 340
 00:44:28.760 --> 00:44:35.259
-danceratopz: But obviously, we need to probably belt DevNet 7 to launch first, just for focus, and then move on to Glamsterdam DevNet 5.
+danceratopz: But obviously, we need to probably bal-devnet-7 to launch first, just for focus, and then move on to Glamsterdam DevNet 5.
 
 341
 00:44:36.170 --> 00:44:37.700
@@ -1426,7 +1426,7 @@ Maria Silva: And so, up until this point, from the benchmarking results we are s
 
 357
 00:46:43.590 --> 00:46:59.089
-Maria Silva: there, what I would suggest is, like, not included in any DevNets. So far, we can still keep it open and see, like, just double-check once we start to see more results from Ball DevNet 7, that the…
+Maria Silva: there, what I would suggest is, like, not included in any DevNets. So far, we can still keep it open and see, like, just double-check once we start to see more results from bal-devnet-7, that the…
 
 358
 00:46:59.900 --> 00:47:12.100
@@ -1490,7 +1490,7 @@ Maria Silva: So I, I, I, I would expect the, changes that we
 
 373
 00:50:03.450 --> 00:50:24.219
-Maria Silva: introduced by adding 80, 38, and 2780 wouldn't change the underlying performance of clients, so I think we could still do benchmarking on Ball DevNet 7 and continue to do benchmarking, in, further forks. Including them on Ball Dev… on Glamsterdam DevNet 5 is more to de-risk the implementation
+Maria Silva: introduced by adding 80, 38, and 2780 wouldn't change the underlying performance of clients, so I think we could still do benchmarking on bal-devnet-7 and continue to do benchmarking, in, further forks. Including them on bal-dev… on Glamsterdam DevNet 5 is more to de-risk the implementation
 
 374
 00:50:24.220 --> 00:50:41.629
@@ -1582,7 +1582,7 @@ danceratopz: If not… I think we can discuss that async.
 
 396
 00:53:04.570 --> 00:53:15.990
-danceratopz: So, I guess, we won't even talk about timing for Glamsterdam Def Note 5. I think, we'll need to get a little bit closer to the date, but one thing that is definitely, worth bringing up ahead of time
+danceratopz: So, I guess, we won't even talk about timing for glamsterdam-devnet-5. I think, we'll need to get a little bit closer to the date, but one thing that is definitely, worth bringing up ahead of time
 
 397
 00:53:16.640 --> 00:53:20.370
@@ -1718,11 +1718,11 @@ danceratopz: Yeah, that's, that's fair comment, and yeah, I think it's just… i
 
 430
 00:56:28.890 --> 00:56:33.089
-danceratopz: So, yeah, we should get it in a definite sooner than later.
+danceratopz: So, yeah, we should get it in a devnet sooner than later.
 
 431
 00:56:33.450 --> 00:56:35.779
-danceratopz: Glamsterdam Definite 5 seems fine.
+danceratopz: glamsterdam-devnet-5 seems fine.
 
 432
 00:56:37.050 --> 00:56:43.909

--- a/.github/ACDbot/artifacts/acdt/2026-05-18_080/transcript_corrected.vtt
+++ b/.github/ACDbot/artifacts/acdt/2026-05-18_080/transcript_corrected.vtt
@@ -850,7 +850,7 @@ danceratopz: Alright, nice. Okay, so…
 
 213
 00:29:49.310 --> 00:29:58.799
-danceratopz: I think to gate, client participation in DevNet 7, it will be, using test spell at V720.
+danceratopz: I think to gate, client participation in DevNet 7, it will be, using tests-bal at v7.2.0.
 
 214
 00:29:59.150 --> 00:30:01.139
@@ -1050,7 +1050,7 @@ danceratopz: Yes, Tony?
 
 263
 00:36:04.170 --> 00:36:16.679
-Toni Wahrstätter: Maybe just to quickly add to that, I just posted a message, based on Maria's, what Maria just said in the Ball Discord. It would be great if clients could have a look, because I know most client teams have been,
+Toni Wahrstätter: Maybe just to quickly add to that, I just posted a message, based on Maria's, what Maria just said in the BAL Discord. It would be great if clients could have a look, because I know most client teams have been,
 
 264
 00:36:16.830 --> 00:36:17.670
@@ -1714,7 +1714,7 @@ Paweł Bylica: So I guess we should consider, like, the pair of these to be incl
 
 429
 00:56:16.120 --> 00:56:28.479
-danceratopz: Yeah, that's, that's fair comment, and yeah, I think it's just… it's important just to make sure that, everyone's aware that it's CFI'd, and basically 7708 already has a 246 as a dependency.
+danceratopz: Yeah, that's, that's fair comment, and yeah, I think it's just… it's important just to make sure that, everyone's aware that it's CFI'd, and basically 7708 already has 8246 as a dependency.
 
 430
 00:56:28.890 --> 00:56:33.089

--- a/.github/ACDbot/artifacts/rpcstandards/2026-05-18_026/tldr.json
+++ b/.github/ACDbot/artifacts/rpcstandards/2026-05-18_026/tldr.json
@@ -73,7 +73,7 @@
   ],
   "decisions": [
     {
-      "timestamp": "00:10:00",
+      "timestamp": "00:12:20",
       "decision": "Merge PR removing eth_getUncle* methods from spec; data unavailable on any current client"
     },
     {

--- a/.github/ACDbot/artifacts/rpcstandards/2026-05-18_026/transcript_corrected.vtt
+++ b/.github/ACDbot/artifacts/rpcstandards/2026-05-18_026/transcript_corrected.vtt
@@ -1686,7 +1686,7 @@ Mercy Boma Naps-Nkari: I'm not sure what's happening.
 
 422
 00:51:31.100 --> 00:51:35.159
-Mercy Boma Naps-Nkari: Although this… I think Gets already mentioned this PR, if I'm not mistaken.
+Mercy Boma Naps-Nkari: Although this… I think Geth already mentioned this PR, if I'm not mistaken.
 
 423
 00:51:38.790 --> 00:51:40.300
@@ -1706,7 +1706,7 @@ sina: Yeah, I, I think it can be merged from our side.
 
 427
 00:52:05.360 --> 00:52:10.950
-Mercy Boma Naps-Nkari: Because it needs to get merged from GET first before we can… Undrafted.
+Mercy Boma Naps-Nkari: Because it needs to get merged from Geth first before we can… Undrafted.
 
 428
 00:52:11.740 --> 00:52:18.109
@@ -1714,7 +1714,7 @@ sina: Right, so the only, the only open question for me was whether we should re
 
 429
 00:52:18.740 --> 00:52:22.830
-sina: pre-London blogs, but I… it seems like Neil is…
+sina: pre-London blocks, but I… it seems like nil is…
 
 430
 00:52:24.590 --> 00:52:27.420
@@ -1734,11 +1734,11 @@ sina: In Gus.
 
 434
 00:52:44.510 --> 00:52:48.339
-Stavros Vlachakis: Another mine side, we are fine. We have also draft implementation.
+Stavros Vlachakis: Nethermind side, we are fine. We have also draft implementation.
 
 435
 00:52:56.940 --> 00:53:00.560
-Mercy Boma Naps-Nkari: I think Bisha has, like, an open PL.
+Mercy Boma Naps-Nkari: I think Besu has, like, an open PR.
 
 436
 00:53:04.900 --> 00:53:05.770
@@ -1758,7 +1758,7 @@ Felix (Geth): Get this PR in if everyone agrees that this method is necessary to
 
 440
 00:53:37.330 --> 00:53:44.449
-Mercy Boma Naps-Nkari: But I have an additional comment, is there also a way to make the spec not to, like, really depend on get?
+Mercy Boma Naps-Nkari: But I have an additional comment, is there also a way to make the spec not to, like, really depend on Geth?
 
 441
 00:53:45.070 --> 00:53:57.779
@@ -1766,7 +1766,7 @@ Felix (Geth): Yeah, I mean, certainly. It's just more that, like, for the curren
 
 442
 00:53:58.390 --> 00:54:03.150
-Felix (Geth): the spec itself doesn't depend on get, just the tests do. But I also think…
+Felix (Geth): the spec itself doesn't depend on Geth, just the tests do. But I also think…
 
 443
 00:54:04.690 --> 00:54:06.520
@@ -1910,7 +1910,7 @@ Felix (Geth): Yo.
 
 478
 00:58:21.870 --> 00:58:31.760
-Mercy Boma Naps-Nkari: Yeah, I think most people are on board, because we have Erigon get, Right, also.
+Mercy Boma Naps-Nkari: Yeah, I think most people are on board, because we have Erigon, Geth, Reth, also.
 
 479
 00:58:33.370 --> 00:58:40.130
@@ -2298,7 +2298,7 @@ Sambhav: like, throw an error that sender is not an EOA.
 
 575
 01:09:46.710 --> 01:10:00.339
-Sambhav: But, like, GET does it, both ways, like, if validation is both on and off, GET does it. Like, I get that comment, but, like, Erigon and Reth both behave like, never mind, just the error code is different. So, yeah, it was my point.
+Sambhav: But, like, Geth does it, both ways, like, if validation is both on and off, Geth does it. Like, I get that comment, but, like, Erigon and Reth both behave like, never mind, just the error code is different. So, yeah, it was my point.
 
 576
 01:10:03.960 --> 01:10:09.369
@@ -2374,7 +2374,7 @@ sina: The issue with this is that…
 
 594
 01:11:52.510 --> 01:11:57.649
-sina: like, the test cases are generated with GET, and it returns a single response.
+sina: like, the test cases are generated with Geth, and it returns a single response.
 
 595
 01:11:58.110 --> 01:12:02.410

--- a/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
+++ b/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
@@ -142,4 +142,11 @@ error_patterns:
   - ETH Lambda: Ethlambda
   - Ball devnet 3: bal-devnet-3
   - Paul devnet 3: bal-devnet-3
+  - Ball devnet: bal-devnet
+  - Valve devnet: bal-devnet
+  - Val devnet: bal-devnet
+  - belt devnet: bal-devnet
   - Glamsterdam devnet 2: glamsterdam-devnet-2
+  - Glamsterdam Def Note: Glamsterdam devnet
+  - Glamsterdam Definite: Glamsterdam devnet
+  - Bisha: Besu

--- a/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
+++ b/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
@@ -7,6 +7,7 @@ clients:
     - Besu
     - Erigon
     - Reth
+    - ethrex
   consensus:
     - Prysm
     - Lighthouse
@@ -150,3 +151,4 @@ error_patterns:
   - Glamsterdam Def Note: Glamsterdam devnet
   - Glamsterdam Definite: Glamsterdam devnet
   - Bisha: Besu
+  - Etherix: ethrex


### PR DESCRIPTION
## Summary
- Added `error_patterns` for variants seen in ACDT 80 and RPC 26:
  - BAL devnet: `Ball devnet`, `Valve devnet`, `Val devnet`, `belt devnet`
  - Glamsterdam devnet: `Glamsterdam Def Note`, `Glamsterdam Definite`
  - Besu: `Bisha`
- Mirrored the corrected transcript artifacts into PM so PM and forkcast copies match (paired with forkcast PR 266).

## Test plan
- [x] Pattern ordering preserves longer-prefix-first rule (`Ball devnet 3` stays above `Ball devnet`)
- [x] Verified mirrored artifacts byte-match the forkcast versions