### PR TITLE
acdbot: fix AWD 39 and PQI 40 transcript corruption

### DIFF
--- a/.github/ACDbot/artifacts/allwalletdevs/2026-05-20_039/transcript_changelog.tsv
+++ b/.github/ACDbot/artifacts/allwalletdevs/2026-05-20_039/transcript_changelog.tsv
@@ -1,3 +1,3 @@
 original	corrected	confidence
-ERCA117	ERC-4117	low
-ERC11A117	ERC-4117	low
+ERCA117	ERC-8117	low
+ERC11A117	ERC-8117	low

--- a/.github/ACDbot/artifacts/allwalletdevs/2026-05-20_039/transcript_corrected.vtt
+++ b/.github/ACDbot/artifacts/allwalletdevs/2026-05-20_039/transcript_corrected.vtt
@@ -38,11 +38,11 @@ Z. Victor Zhou (xinbenlv): Okay, I think we can wait another one minute, and the
 
 10
 00:05:12.270 --> 00:05:23.359
-Z. Victor Zhou (xinbenlv): Yes, I want to chat about ERC-4117. I want to give a quick update about A117. It's 5 minutes, so let me get started with it.
+Z. Victor Zhou (xinbenlv): Yes, I want to chat about ERC-8117. I want to give a quick update about 8117. It's 5 minutes, so let me get started with it.
 
 11
 00:05:23.580 --> 00:05:27.389
-Z. Victor Zhou (xinbenlv): So if you go to ERC137,
+Z. Victor Zhou (xinbenlv): So if you go to ERC-8117,
 
 12
 00:05:27.530 --> 00:05:32.249
@@ -54,7 +54,7 @@ Z. Victor Zhou (xinbenlv): And, this is the link.
 
 14
 00:05:44.200 --> 00:05:55.089
-Z. Victor Zhou (xinbenlv): we… recently make a change to the ERC-4117, primarily changing the superscript to subscript.
+Z. Victor Zhou (xinbenlv): we… recently make a change to the ERC-8117, primarily changing the superscript to subscript.
 
 15
 00:05:55.160 --> 00:06:14.560
@@ -82,7 +82,7 @@ Z. Victor Zhou (xinbenlv): I would love to, get some feedback before we finalize
 
 21
 00:06:51.610 --> 00:06:59.180
-Z. Victor Zhou (xinbenlv): poisoning, since, like, Azra's poisoning has been raised multiple times in the past few months and becomes a…
+Z. Victor Zhou (xinbenlv): poisoning, since, like, address poisoning has been raised multiple times in the past few months and becomes a…
 
 22
 00:06:59.190 --> 00:07:13.060
@@ -90,7 +90,7 @@ Z. Victor Zhou (xinbenlv): increasing security concern. So we want to bring this
 
 23
 00:07:13.500 --> 00:07:20.439
-Z. Victor Zhou (xinbenlv): And my name is Victor. I am the author of the RC8117.
+Z. Victor Zhou (xinbenlv): And my name is Victor. I am the author of the ERC-8117.
 
 24
 00:07:20.670 --> 00:07:21.570

--- a/.github/ACDbot/artifacts/pqinterop/2026-05-20_040/tldr.json
+++ b/.github/ACDbot/artifacts/pqinterop/2026-05-20_040/tldr.json
@@ -46,7 +46,7 @@
     "research_and_spec": [
       {
         "timestamp": "00:13:24",
-        "highlight": "Plonky3 optimization PRs merged; full benchmarking suite for WEER and new Monolis arithmetization added"
+        "highlight": "Plonky3 optimization PRs merged; full benchmarking suite for WEER and new Monolith arithmetization added"
       },
       {
         "timestamp": "00:15:26",

--- a/.github/ACDbot/artifacts/pqinterop/2026-05-20_040/transcript_corrected.vtt
+++ b/.github/ACDbot/artifacts/pqinterop/2026-05-20_040/transcript_corrected.vtt
@@ -114,7 +114,7 @@ Gajinder Singh: And, on the test runs, we further integrated,
 
 29
 00:06:41.240 --> 00:06:47.609
-Gajinder Singh: The tests that were, updated on the LeanSpec, and…
+Gajinder Singh: The tests that were, updated on the lean spec, and…
 
 30
 00:06:47.830 --> 00:06:51.629
@@ -122,7 +122,7 @@ Gajinder Singh: We have been, keeping up with the Hive integrations as well.
 
 31
 00:06:52.280 --> 00:07:02.009
-Gajinder Singh: on… on DevNetRuns, Partha will give you update for scaling the validators, because we started scaling the validators.
+Gajinder Singh: on… on DevNet runs, Partha will give you update for scaling the validators, because we started scaling the validators.
 
 32
 00:07:02.120 --> 00:07:09.299
@@ -130,11 +130,11 @@ Gajinder Singh: And again, as expected, we started running into, again, the chok
 
 33
 00:07:09.600 --> 00:07:28.670
-Gajinder Singh: that were expected, and we expect various clients to look into it and resolve those issues. On Zoom's side, we will be focusing on improving our aggregation computation itself. That is something that has come out to be a clear priority for us.
+Gajinder Singh: that were expected, and we expect various clients to look into it and resolve those issues. On Zeam's side, we will be focusing on improving our aggregation computation itself. That is something that has come out to be a clear priority for us.
 
 34
 00:07:28.800 --> 00:07:34.350
-Gajinder Singh: So this is… Overall picture on Zoom's end.
+Gajinder Singh: So this is… Overall picture on Zeam's end.
 
 35
 00:07:38.600 --> 00:07:40.120
@@ -142,7 +142,7 @@ Thomas Coratger: Great, thanks a lot.
 
 36
 00:07:41.070 --> 00:07:41.950
-Thomas Coratger: a ring?
+Thomas Coratger: Ream?
 
 37
 00:07:43.730 --> 00:07:55.010
@@ -154,7 +154,7 @@ Shariq Naiyer: I forget exactly, but it was allowing you to use older justified 
 
 39
 00:08:04.040 --> 00:08:17.009
-Shariq Naiyer: We're looking through the demo site spec and implementing it now, and, we've explored some metrics around application, that were missing, from… so Partha couldn't tell us what our application time was.
+Shariq Naiyer: We're looking through the DevNet 5 spec and implementing it now, and, we've explored some metrics around application, that were missing, from… so Partha couldn't tell us what our application time was.
 
 40
 00:08:17.260 --> 00:08:38.859
@@ -162,7 +162,7 @@ Shariq Naiyer: And on Hive, we're adding tests for multi-subnet, interop, so cli
 
 41
 00:08:42.130 --> 00:08:45.180
-Thomas Coratger: Great, thanks a lot. Clean.
+Thomas Coratger: Great, thanks a lot. Qlean.
 
 42
 00:08:47.110 --> 00:08:53.710
@@ -182,7 +182,7 @@ Ruslan Tushov: Thank you.
 
 46
 00:09:16.380 --> 00:09:18.610
-Thomas Coratger: Great, thank you, Lantion.
+Thomas Coratger: Great, thank you, Lantern.
 
 47
 00:09:28.860 --> 00:09:30.050
@@ -194,11 +194,11 @@ Pablo Deymo | Lambda: No, hello.
 
 49
 00:09:33.560 --> 00:09:42.270
-Pablo Deymo | Lambda: We made a VR to Linuxpec, fixing an edge case in block buildings, and that was already merged.
+Pablo Deymo | Lambda: We made a PR to lean spec, fixing an edge case in block building, and that was already merged.
 
 50
 00:09:42.520 --> 00:09:52.570
-Pablo Deymo | Lambda: It's already emerged. We saw some other instability due to useless attestations being included in build blocks.
+Pablo Deymo | Lambda: It's already merged. We saw some other instability due to useless attestations being included in build blocks.
 
 51
 00:09:52.830 --> 00:09:59.449
@@ -206,7 +206,7 @@ Pablo Deymo | Lambda: And so, we are already testing some changes to block build
 
 52
 00:09:59.690 --> 00:10:04.189
-Pablo Deymo | Lambda: And we will make a PR Kooly inspect for this afterwards.
+Pablo Deymo | Lambda: And we will make a PR coming to lean spec for this afterwards.
 
 53
 00:10:05.210 --> 00:10:10.280
@@ -230,11 +230,11 @@ Pablo Deymo | Lambda: So, that's our science.
 
 58
 00:10:35.610 --> 00:10:39.969
-Thomas Coratger: Great, thanks a lot for the PRs on Linspecca as well.
+Thomas Coratger: Great, thanks a lot for the PRs on lean spec as well.
 
 59
 00:10:40.600 --> 00:10:43.419
-Thomas Coratger: Now, Gin?
+Thomas Coratger: Now, Gean?
 
 60
 00:10:45.600 --> 00:10:47.190
@@ -242,7 +242,7 @@ Shaaibu Suleiman | gean: Yes, hello, hello.
 
 61
 00:10:47.360 --> 00:10:58.220
-Shaaibu Suleiman | gean: Yeah, so, from our own site, we've been, making some, updates, basically, some merged, pull requests for the FNet4, I think on Lynchwork as they come.
+Shaaibu Suleiman | gean: Yeah, so, from our own side, we've been, making some, updates, basically, some merged, pull requests for the DevNet 4, I think on networking as they come.
 
 62
 00:10:58.370 --> 00:11:08.479
@@ -270,7 +270,7 @@ Thomas Coratger: Okay, and Grandine?
 
 68
 00:11:38.950 --> 00:11:45.869
-Mercy Boma Naps-Nkari: Good afternoon, so… We received an OM report from the general government, and then we did an internal run.
+Mercy Boma Naps-Nkari: Good afternoon, so… We received an OOM report from the general devnet, and then we did an internal run.
 
 69
 00:11:46.060 --> 00:11:48.849
@@ -282,7 +282,7 @@ Mercy Boma Naps-Nkari: So, we are still trying to figure out why.
 
 71
 00:11:53.140 --> 00:11:59.720
-Mercy Boma Naps-Nkari: this OM issue occurs, on the generative net and not, in our own internal one, so…
+Mercy Boma Naps-Nkari: this OOM issue occurs, on the general devnet and not, in our own internal one, so…
 
 72
 00:11:59.840 --> 00:12:06.509
@@ -310,7 +310,7 @@ Thomas Coratger: Great. Thanks, thanks a lot, Nimbus.
 
 78
 00:12:47.140 --> 00:12:50.479
-Thomas Coratger: Yep, so, yeah, and Lynn? Yeah.
+Thomas Coratger: Yep, so, yeah, and Lean? Yeah.
 
 79
 00:12:58.480 --> 00:13:01.009
@@ -330,7 +330,7 @@ Thomas Coratger: No, first, maybe on the research side.
 
 83
 00:13:20.720 --> 00:13:24.399
-Thomas Coratger: we have merged, like, a couple of new PRs in Plonkey 3.
+Thomas Coratger: we have merged, like, a couple of new PRs in Plonky3.
 
 84
 00:13:24.660 --> 00:13:27.939
@@ -346,7 +346,7 @@ Thomas Coratger: We have merged also a full benchmarking suite for WEER, that is
 
 87
 00:13:39.050 --> 00:13:46.379
-Thomas Coratger: We have also merged a new arithmization for Monolis, that is an arithmeticization-friendly hash function.
+Thomas Coratger: We have also merged a new arithmization for Monolith, that is an arithmetization-friendly hash function.
 
 88
 00:13:46.650 --> 00:13:49.450
@@ -362,7 +362,7 @@ Thomas Coratger: Just to test and stuff, so we have done that.
 
 91
 00:14:01.720 --> 00:14:11.609
-Thomas Coratger: not that much new things since Roam on the research side. Maybe, immediately want to complete with the new stuff that you are doing right now in LeanVM?
+Thomas Coratger: not that much new things since Rome on the research side. Maybe, Emil, you want to complete with the new stuff that you are doing right now in LeanVM?
 
 92
 00:14:12.270 --> 00:14:15.759
@@ -370,11 +370,11 @@ T. Wambsgans: Hi, everyone. Yeah, mostly working on…
 
 93
 00:14:16.160 --> 00:14:20.920
-T. Wambsgans: improving the spec and the paper associated to LinVM.
+T. Wambsgans: improving the spec and the paper associated to LeanVM.
 
 94
 00:14:21.270 --> 00:14:32.720
-T. Wambsgans: there is no quickly web-coded Python verifier implementation, which is, like, 1,500 lines of code.
+T. Wambsgans: there is now a quickly hand-coded Python verifier implementation, which is, like, 1,500 lines of code.
 
 95
 00:14:32.720 --> 00:14:41.769
@@ -382,7 +382,7 @@ T. Wambsgans: I… as soon as the spec paper is, good enough, I will have a look
 
 96
 00:14:41.940 --> 00:14:50.920
-T. Wambsgans: To try to make it below 1,000 lines of code, and then trying to… write a LIN4 verifier.
+T. Wambsgans: To try to make it below 1,000 lines of code, and then trying to… write a Lean4 verifier.
 
 97
 00:14:51.470 --> 00:14:55.230
@@ -394,7 +394,7 @@ T. Wambsgans: Like, at least, having a well-defined,
 
 99
 00:14:58.660 --> 00:15:02.919
-T. Wambsgans: verifier for LinVM. That's the current goal.
+T. Wambsgans: verifier for LeanVM. That's the current goal.
 
 100
 00:15:07.110 --> 00:15:08.210
@@ -414,19 +414,19 @@ Thomas Coratger: since after ROM, on the spec, on lean spec.
 
 104
 00:15:26.450 --> 00:15:43.540
-Thomas Coratger: because we are entering a bit of a phase of, I think, a stabilization, and I want to showcase also, like, the specification to, like, a more broader audience. We are discussing that internally at DEF, and I want… I would love, like, to have more feedbacks about
+Thomas Coratger: because we are entering a bit of a phase of, I think, a stabilization, and I want to showcase also, like, the specification to, like, a more broader audience. We are discussing that internally at EF, and I want… I would love, like, to have more feedbacks about
 
 105
 00:15:44.180 --> 00:16:01.630
-Thomas Coratger: existing Beacon client teams, and also, like, more people inside ZEF and outside ZF, the ones that are doing, like, currently the Beacon specification, just to see if they agree or not with how we are doing specification.
+Thomas Coratger: existing Beacon client teams, and also, like, more people inside EF and outside EF, the ones that are doing, like, currently the Beacon specification, just to see if they agree or not with how we are doing specification.
 
 106
 00:16:01.750 --> 00:16:18.499
-Thomas Coratger: That's why I am trying to clean things up a lot since this weekend. So, for example, basic example, I have reworked a bit, like, the way we are doing some SSD types, and trying to add more test coverage when missing.
+Thomas Coratger: That's why I am trying to clean things up a lot since this weekend. So, for example, basic example, I have reworked a bit, like, the way we are doing some SSZ types, and trying to add more test coverage when missing.
 
 107
 00:16:18.630 --> 00:16:29.780
-Thomas Coratger: I have completely removed this morning, as well, the Disk 5… diskv5, discovery stuff, because we are not using it, and we don't need that for a spec or a minimal client.
+Thomas Coratger: I have completely removed this morning, as well, the discv5… discv5, discovery stuff, because we are not using it, and we don't need that for a spec or a minimal client.
 
 108
 00:16:29.930 --> 00:16:33.359
@@ -446,7 +446,7 @@ Thomas Coratger: So I am spending a bit of time on this, to architecture things 
 
 112
 00:17:00.080 --> 00:17:10.420
-Thomas Coratger: days, and weeks, probably. At the end of this week, I am going with, with Antonio from, and, and, and Justine from ZEF,
+Thomas Coratger: days, and weeks, probably. At the end of this week, I am going with, with Antonio from EF, and Justin from EF,
 
 113
 00:17:10.660 --> 00:17:16.080
@@ -470,11 +470,11 @@ Thomas Coratger: So that is the good news. No, I think that we can stabilize the
 
 118
 00:17:44.960 --> 00:17:52.229
-Thomas Coratger: Also, I think that this is pretty aligned with the comments that I have seen from Bartai in the issue.
+Thomas Coratger: Also, I think that this is pretty aligned with the comments that I have seen from Partha in the issue.
 
 119
 00:17:52.820 --> 00:18:04.110
-Thomas Coratger: of this meeting. Basically, PATA is proposing, like, to defining the clear acceptance criteria for each DevNet, because I think that the complaint is a bit that we are
+Thomas Coratger: of this meeting. Basically, Partha is proposing, like, to defining the clear acceptance criteria for each DevNet, because I think that the complaint is a bit that we are
 
 120
 00:18:04.270 --> 00:18:07.140
@@ -482,7 +482,7 @@ Thomas Coratger: We have not reached stability yet.
 
 121
 00:18:07.530 --> 00:18:13.899
-Thomas Coratger: And this is a bit of a mess right now to debug the .NET, so basically what I propose now is that
+Thomas Coratger: And this is a bit of a mess right now to debug the DevNet, so basically what I propose now is that
 
 122
 00:18:14.200 --> 00:18:24.230
@@ -510,7 +510,7 @@ Parthasarathy Ramanujam: Sorry, was that a question to me, Thomas?
 
 128
 00:19:09.990 --> 00:19:23.420
-Thomas Coratger: No… not specifically, but I think that in the issue of, like, the… in the issue of the… of the two-day calls, you mentioned the fact that we… we should have clear acceptance criteria for EastDevNets.
+Thomas Coratger: No… not specifically, but I think that in the issue of, like, the… in the issue of the… of the two-day calls, you mentioned the fact that we… we should have clear acceptance criteria for each DevNet.
 
 129
 00:19:23.420 --> 00:19:23.880
@@ -574,7 +574,7 @@ Parthasarathy Ramanujam: 30 different servers. So, but before we could, really s
 
 144
 00:21:39.370 --> 00:21:47.300
-Parthasarathy Ramanujam: try to see that at least P95 across all plants is achieved within that 0.8 second interval.
+Parthasarathy Ramanujam: try to see that at least P95 across all clients is achieved within that 0.8 second interval.
 
 145
 00:21:47.630 --> 00:21:50.350
@@ -582,7 +582,7 @@ Parthasarathy Ramanujam: Yeah, that's all I had. Sorry, Gajinder, you can go for
 
 146
 00:21:55.620 --> 00:21:57.330
-Thomas Coratger: Yes, please get Ginger, go ahead.
+Thomas Coratger: Yes, please Gajinder, go ahead.
 
 147
 00:21:57.800 --> 00:22:06.469
@@ -766,7 +766,7 @@ Thomas Coratger: Yeah, please, hold, go, go ahead.
 
 192
 00:28:34.580 --> 00:28:50.459
-unnawut: Yeah, just want to share some numbers, from the bench, from the feedback that Toma, gave last time that I… I benchmarked against, main branch, and that's more performant, but that's not what we are using for… for DemNet 4 and 5.
+unnawut: Yeah, just want to share some numbers, from the bench, from the feedback that Thomas gave last time that I… I benchmarked against, main branch, and that's more performant, but that's not what we are using for… for DevNet 4 and 5.
 
 193
 00:28:50.460 --> 00:28:58.209
@@ -850,7 +850,7 @@ unnawut: Yeah, so… and I think, like, the recursion, like, it doesn't matter h
 
 213
 00:30:56.610 --> 00:31:02.120
-unnawut: Like, we are looking at, 2.7 seconds on a 32 car.
+unnawut: Like, we are looking at, 2.7 seconds on a 32 core.
 
 214
 00:31:02.290 --> 00:31:11.590
@@ -946,7 +946,7 @@ Thomas Coratger: Even, I think, in Rome, we benchmark within my laptop, which is
 
 237
 00:34:20.270 --> 00:34:37.700
-Parthasarathy Ramanujam: I follow, but given that we are running everything on Headsner, and Headsner does not provide M-related stuff, so I just need to understand if we can… what is the minimum configuration we should target for? So if it's 16 core, that's fine. If it's 32 core, that's fine.
+Parthasarathy Ramanujam: I follow, but given that we are running everything on Hetzner, and Hetzner does not provide M-related stuff, so I just need to understand if we can… what is the minimum configuration we should target for? So if it's 16 core, that's fine. If it's 32 core, that's fine.
 
 238
 00:34:37.699 --> 00:34:42.479
@@ -970,7 +970,7 @@ T. Wambsgans: But there is the number of cores, but there is also the performanc
 
 243
 00:35:04.780 --> 00:35:13.870
-T. Wambsgans: And, typically, I have, like, a small Etsnaire server, and it's much slower than the Mac.
+T. Wambsgans: And, typically, I have, like, a small Hetzner server, and it's much slower than the Mac.
 
 244
 00:35:14.160 --> 00:35:17.659
@@ -982,7 +982,7 @@ T. Wambsgans: So…
 
 246
 00:35:19.190 --> 00:35:33.010
-T. Wambsgans: it's hard for me to give, right now, precise, requirements, but we can try to write them down for the next call, probably. But I think 16 calls is,
+T. Wambsgans: it's hard for me to give, right now, precise, requirements, but we can try to write them down for the next call, probably. But I think 16 cores is,
 
 247
 00:35:33.280 --> 00:35:34.420
@@ -1010,7 +1010,7 @@ T. Wambsgans: in some way, like, as a random oracle, you can get tighter and mor
 
 253
 00:36:09.720 --> 00:36:15.629
-T. Wambsgans: also has the advantage of being below 1 MTU and EPV6 MTU.
+T. Wambsgans: also has the advantage of being below 1 MTU and IPv6 MTU.
 
 254
 00:36:16.210 --> 00:36:32.110
@@ -1238,7 +1238,7 @@ Mega | Lambda: That block building might be a problem.
 
 310
 00:45:22.730 --> 00:45:34.699
-Mega | Lambda: We have a PR in Lambda improving the block building algorithms. We've already been running some debits with that, and we know this justification and finality
+Mega | Lambda: We have a PR in Lambda improving the block building algorithms. We've already been running some devnets with that, and we now see justification and finality
 
 311
 00:45:34.880 --> 00:45:36.640
@@ -1246,7 +1246,7 @@ Mega | Lambda: Improving soon.
 
 312
 00:45:36.800 --> 00:45:40.940
-Mega | Lambda: we can… We can make a PR to Lynn Sprinkle.
+Mega | Lambda: we can… We can make a PR to lean spec.
 
 313
 00:45:41.180 --> 00:45:44.420
@@ -1366,7 +1366,7 @@ Mega | Lambda: use that to try to run with Lambda with execution clients. We mad
 
 342
 00:49:17.850 --> 00:49:25.849
-Mega | Lambda: for, for MNET 6. We basically copied part of the Beacon spec to…
+Mega | Lambda: for, for DevNet 6. We basically copied part of the Beacon spec to…
 
 343
 00:49:27.120 --> 00:49:36.270
@@ -1386,7 +1386,7 @@ Mega | Lambda: the Ethereum package integration we have.
 
 347
 00:49:51.680 --> 00:50:00.950
-Mega | Lambda: We have this package in our… in our Lambda Glass 4 of Ethereum package. It's number 19, so if anyone's interested.
+Mega | Lambda: We have this package in our… in our lambdaclass fork of Ethereum package. It's number 19, so if anyone's interested.
 
 348
 00:50:02.360 --> 00:50:09.779
@@ -1470,7 +1470,7 @@ Mega | Lambda: the… The configuration we are using is this one.
 
 368
 00:52:01.190 --> 00:52:07.820
-Mega | Lambda: We have ethrex with Atlanta, ethrex with Lambda, Nethermind, Geth, Erigon, Nimbus, and Besu.
+Mega | Lambda: We have ethrex with Ethlambda, ethrex with Lambda, Nethermind, Geth, Erigon, Nimbus, and Besu.
 
 369
 00:52:08.550 --> 00:52:11.899
@@ -1490,7 +1490,7 @@ Mega | Lambda: We can see here that it's processing blocks execution, nearly at 
 
 373
 00:52:35.360 --> 00:52:39.549
-Mega | Lambda: You should see some form choice updated messages.
+Mega | Lambda: You should see some fork choice updated messages.
 
 374
 00:52:42.780 --> 00:52:43.830
@@ -1502,7 +1502,7 @@ Mega | Lambda: Dude Here I have… Yeah, basically these ones, full choice updat
 
 376
 00:52:55.390 --> 00:52:58.660
-Mega | Lambda: If Lambda is asking the Yale for a…
+Mega | Lambda: Ethlambda is asking the EL for a…
 
 377
 00:52:58.810 --> 00:53:07.850
@@ -1518,7 +1518,7 @@ Mega | Lambda: You can see maybe that on Ethlambda Logs.
 
 380
 00:53:18.100 --> 00:53:20.150
-Mega | Lambda: In Islam, no.
+Mega | Lambda: In Ethlambda, no.
 
 381
 00:53:25.700 --> 00:53:27.910

--- a/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
+++ b/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
@@ -84,6 +84,8 @@ orgs:
   - Consensys
   - Offchain Labs
   - EthPandaOps
+  - Hetzner
+  - lambdaclass
 
 technical_terms:
   - blob
@@ -100,6 +102,13 @@ technical_terms:
   - opcode
   - gas limit
   - mempool
+  - lean spec
+  - LeanVM
+  - Lean4
+  - Plonky3
+  - Monolith
+  - XMSS
+  - arithmetization
 
 # Common transcription errors
 error_patterns:
@@ -168,3 +177,20 @@ error_patterns:
   - sparse code pool: sparse blob pool
   - buffal pool: blob pool
   - BlowPool: blob pool
+  - Headsner: Hetzner
+  - Etsnaire: Hetzner
+  - Hetsner: Hetzner
+  - LinVM: LeanVM
+  - LIN4: Lean4
+  - Plonkey 3: Plonky3
+  - Plonkey3: Plonky3
+  - Monolis: Monolith
+  - Lantion: Lantern
+  - Linuxpec: lean spec
+  - Linspecca: lean spec
+  - Lynn Sprinkle: lean spec
+  - Lynchwork: networking
+  - Zoom's side: Zeam's side
+  - Zoom's end: Zeam's end
+  - Lambda Glass 4: lambdaclass fork
+  - arithmeticization: arithmetization


### PR DESCRIPTION
Two-call fix bundle. Adds new vocab entries so future calls auto-correct, and patches the already-published artifacts for these two calls.

**AWD 39**
- Pipeline mis-corrected `ERCA117` / `ERC11A117` to `ERC-4117`; chat link confirms the EIP is **ERC-8117**. All ERC mentions normalized.
- `Azra's poisoning` → `address poisoning`.

**PQI 40**
- Hetzner: `Headsner` / `Etsnaire` → `Hetzner`
- Lean spec / clients: `LeanSpec` / `Linuxpec` / `Linspecca` / `Lynn Sprinkle` → `lean spec`; `LinVM` → `LeanVM`; `LIN4` → `Lean4`; `Lantion` → `Lantern`; `Atlanta` / `Islam` → `Ethlambda`; `a ring?` → `Ream?`; `Clean` → `Qlean`; `Now Gin?` → `Now Gean?`; `and Lynn?` → `and Lean?`
- Self-references: `Zoom's side/end` → `Zeam's side/end`
- Research: `Plonkey 3` → `Plonky3`; `Monolis` → `Monolith`; `arithmeticization` → `arithmetization`
- `lambdaclass fork` misheard as `Lambda Glass 4`
- `Yale` → `EL`; `form choice updated` → `fork choice updated`
- DevNet variants: `FNet4` → `DevNet 4`, `DemNet` → `DevNet`, `EastDevNets` → `each DevNet`, `MNET 6` → `DevNet 6`, `.NET` → `DevNet`
- People: `Bartai` / `PATA` → `Partha`; `Toma` → `Thomas`; `get Ginger` → `Gajinder`; `Justine from ZEF` → `Justin from EF`
- Misc: `OM` → `OOM`; `generative net` / `general government` → `general devnet`; `all plants` → `all clients`; `32 car` → `32 core`; `16 calls` → `16 cores`; `EPV6` → `IPv6`; `SSD types` → `SSZ types`; `Disk 5` → `discv5`; `Roam` → `Rome`; `Lynchwork` → `networking`; `ZEF` / `ZF` / `DEF` → `EF`; `we know this justification` → `we now see justification`

**Vocab additions**: new terms (Hetzner, lambdaclass, LeanVM, Lean4, Plonky3, Monolith, XMSS, arithmetization, lean spec) and safe error_patterns for the unique-string corruptions above. Skipped global patterns for `Zoom` (too generic) and personal names (`Bartai`, `PATA`).