### PR TITLE
[codex] Add ACD video sandwich test workflow

### DIFF
--- a/.github/ACDbot/docs/video_sandwich_test.md
+++ b/.github/ACDbot/docs/video_sandwich_test.md
@@ -1,0 +1,26 @@
+# ACD Video Sandwich Test
+
+This workflow tests whether PM can build a recorded ACD video from:
+
+```text
+first half of ev.mp4 + Zoom MP4 + last half of ev.mp4
+```
+
+## Viability
+
+- `ffmpeg` is the right tool for this test. It can trim the bumper, normalize frame size/rate/audio, concatenate the three segments, and write a YouTube-friendly MP4 with `+faststart`.
+- The workflow should not commit `ev.mp4` directly to the repository. The local file is about 89 MB, which is near GitHub's ordinary repository file limit and would bloat clone history. Store it as a release asset, Git LFS object, or external object-storage URL, then expose that URL as `ACD_BUMPER_URL`.
+- GitHub-hosted runners are viable for a proof of concept, but standard runners have limited disk. A full job needs room for the downloaded Zoom file, bumper, intermediate decode/encode work, and final MP4.
+- GitHub Actions artifacts work for a short-lived downloadable proof artifact. Keep retention low because private-repo artifact quotas are small.
+- YouTube upload by API is viable for normal uploads and scheduled publishing. A true Premiere may still require YouTube Studio or a non-Data-API integration because the public Data API exposes `publishAt` scheduling but not a documented `set as Premiere` upload flag.
+
+## Required Configuration
+
+The workflow expects these values to be available to PRs from branches in the repository:
+
+- `ACD_BUMPER_URL`: repository variable or secret pointing to a downloadable `ev.mp4`
+- `ZOOM_CLIENT_ID`
+- `ZOOM_CLIENT_SECRET`
+- `ZOOM_REFRESH_TOKEN`
+
+The workflow is skipped for forked PRs because GitHub does not expose repository secrets to untrusted pull requests.

--- a/.github/ACDbot/scripts/compose_zoom_sandwich.py
+++ b/.github/ACDbot/scripts/compose_zoom_sandwich.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Compose an ACD recording with an intro/outro bumper.
+
+The output shape is:
+
+    first half of bumper + Zoom recording + last half of bumper
+
+Zoom access and local process execution are kept at the script edge so the
+selection and ffmpeg command construction stay easy to test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ACDBOT_DIR = Path(__file__).resolve().parents[1]
+MAPPING_FILE_PATH = ACDBOT_DIR / "meeting_topic_mapping.json"
+
+
+@dataclass(frozen=True)
+class OccurrenceTarget:
+    series: str
+    meeting_id: str
+    issue_number: int | None
+    title: str
+    start_time: str | None
+
+
+def parse_utc_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def select_occurrence_candidates(
+    mapping: dict[str, Any],
+    series: str,
+    number: int | None = None,
+    now: datetime | None = None,
+) -> list[OccurrenceTarget]:
+    """Return newest plausible mapped occurrences for a call series."""
+    series_entry = mapping.get(series)
+    if not series_entry:
+        raise ValueError(f"Series '{series}' was not found in {MAPPING_FILE_PATH}")
+
+    meeting_id = str(series_entry.get("meeting_id") or "")
+    if not meeting_id:
+        raise ValueError(f"Series '{series}' does not have a meeting_id")
+
+    now = now or datetime.now(timezone.utc)
+    candidates: list[OccurrenceTarget] = []
+
+    for occurrence in series_entry.get("occurrences", []):
+        start_time = occurrence.get("start_time")
+        start_dt = parse_utc_timestamp(start_time)
+
+        if number is not None and occurrence.get("occurrence_number") != number:
+            continue
+        if number is None and start_dt and start_dt > now:
+            continue
+
+        issue_number = occurrence.get("issue_number")
+        candidates.append(
+            OccurrenceTarget(
+                series=series,
+                meeting_id=meeting_id,
+                issue_number=int(issue_number) if issue_number is not None else None,
+                title=occurrence.get("issue_title") or f"{series.upper()} recording",
+                start_time=start_time,
+            )
+        )
+
+    candidates.sort(
+        key=lambda item: parse_utc_timestamp(item.start_time) or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
+    return candidates
+
+
+def probe_duration(path: Path) -> float:
+    command = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "json",
+        str(path),
+    ]
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    duration = float(json.loads(result.stdout)["format"]["duration"])
+    if duration <= 0:
+        raise ValueError(f"Could not determine a positive duration for {path}")
+    return duration
+
+
+def build_ffmpeg_command(
+    bumper_path: Path,
+    zoom_path: Path,
+    output_path: Path,
+    bumper_duration: float,
+    width: int = 1280,
+    height: int = 720,
+    fps: int = 30,
+) -> list[str]:
+    half = bumper_duration / 2
+    video_normalize = (
+        f"scale={width}:{height}:force_original_aspect_ratio=decrease,"
+        f"pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:color=black,"
+        f"setsar=1,fps={fps},format=yuv420p"
+    )
+    audio_normalize = "aformat=sample_fmts=fltp:sample_rates=48000:channel_layouts=stereo"
+    filter_complex = ";".join(
+        [
+            f"[0:v]trim=start=0:end={half:.6f},setpts=PTS-STARTPTS,{video_normalize}[v0]",
+            f"[0:a]atrim=start=0:end={half:.6f},asetpts=PTS-STARTPTS,{audio_normalize}[a0]",
+            f"[1:v]setpts=PTS-STARTPTS,{video_normalize}[v1]",
+            f"[1:a]asetpts=PTS-STARTPTS,{audio_normalize}[a1]",
+            f"[0:v]trim=start={half:.6f}:end={bumper_duration:.6f},setpts=PTS-STARTPTS,{video_normalize}[v2]",
+            f"[0:a]atrim=start={half:.6f}:end={bumper_duration:.6f},asetpts=PTS-STARTPTS,{audio_normalize}[a2]",
+            "[v0][a0][v1][a1][v2][a2]concat=n=3:v=1:a=1[v][a]",
+        ]
+    )
+    return [
+        "ffmpeg",
+        "-y",
+        "-hide_banner",
+        "-i",
+        str(bumper_path),
+        "-i",
+        str(zoom_path),
+        "-filter_complex",
+        filter_complex,
+        "-map",
+        "[v]",
+        "-map",
+        "[a]",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "veryfast",
+        "-crf",
+        "23",
+        "-c:a",
+        "aac",
+        "-b:a",
+        "160k",
+        "-movflags",
+        "+faststart",
+        str(output_path),
+    ]
+
+
+def download_zoom_recording_for_latest_candidate(
+    candidates: list[OccurrenceTarget],
+    min_duration: int,
+    max_candidates: int,
+) -> tuple[OccurrenceTarget, Path]:
+    from scripts.upload_zoom_recording import download_zoom_recording
+
+    attempted = candidates[:max_candidates]
+    if not attempted:
+        raise ValueError("No mapped occurrences matched the requested series/number")
+
+    for candidate in attempted:
+        print(
+            "[INFO] Trying Zoom recording for "
+            f"{candidate.series.upper()} issue={candidate.issue_number} start={candidate.start_time}"
+        )
+        video_path = download_zoom_recording(
+            candidate.meeting_id,
+            min_duration_minutes=min_duration,
+            target_start_time=candidate.start_time,
+            tolerance_minutes=180,
+        )
+        if video_path:
+            return candidate, Path(video_path)
+
+    raise RuntimeError(f"No downloadable Zoom MP4 was found after trying {len(attempted)} candidate(s)")
+
+
+def write_metadata(path: Path, target: OccurrenceTarget, zoom_path: Path, output_path: Path) -> None:
+    metadata = {
+        "series": target.series,
+        "meeting_id": target.meeting_id,
+        "issue_number": target.issue_number,
+        "title": target.title,
+        "start_time": target.start_time,
+        "zoom_file": str(zoom_path),
+        "output_file": str(output_path),
+        "output_size_bytes": output_path.stat().st_size if output_path.exists() else None,
+    }
+    path.write_text(json.dumps(metadata, indent=2) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Create an intro + Zoom + outro test video")
+    parser.add_argument("--series", default="acde", help="Call series key from meeting_topic_mapping.json")
+    parser.add_argument("--number", type=int, help="Public occurrence number, e.g. 236")
+    parser.add_argument("--bumper", required=True, type=Path, help="Path to ev.mp4 or equivalent bumper")
+    parser.add_argument("--output", required=True, type=Path, help="Path for the stitched MP4")
+    parser.add_argument("--metadata", type=Path, help="Optional JSON metadata output path")
+    parser.add_argument("--min-duration", type=int, default=10, help="Minimum Zoom recording duration in minutes")
+    parser.add_argument("--max-candidates", type=int, default=5, help="How many recent occurrences to try")
+    args = parser.parse_args()
+
+    if not args.bumper.exists():
+        raise FileNotFoundError(f"Bumper file does not exist: {args.bumper}")
+
+    with MAPPING_FILE_PATH.open() as file:
+        mapping = json.load(file)
+
+    candidates = select_occurrence_candidates(mapping, args.series, args.number)
+    target, zoom_path = download_zoom_recording_for_latest_candidate(
+        candidates,
+        min_duration=args.min_duration,
+        max_candidates=args.max_candidates,
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    bumper_duration = probe_duration(args.bumper)
+    command = build_ffmpeg_command(args.bumper, zoom_path, args.output, bumper_duration)
+
+    print(f"[INFO] Bumper duration: {bumper_duration:.3f}s")
+    print(f"[INFO] Composing output: {args.output}")
+    subprocess.run(command, check=True)
+
+    if args.metadata:
+        args.metadata.parent.mkdir(parents=True, exist_ok=True)
+        write_metadata(args.metadata, target, zoom_path, args.output)
+
+    try:
+        os.unlink(zoom_path)
+    except FileNotFoundError:
+        pass
+
+    print(f"[SUCCESS] Wrote {args.output} ({args.output.stat().st_size / 1024 / 1024:.1f} MiB)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/ACDbot/tests/unit/test_compose_zoom_sandwich.py
+++ b/.github/ACDbot/tests/unit/test_compose_zoom_sandwich.py
@@ -1,0 +1,76 @@
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts.compose_zoom_sandwich import build_ffmpeg_command, select_occurrence_candidates
+
+
+def test_select_occurrence_candidates_returns_latest_past_occurrences():
+    mapping = {
+        "acde": {
+            "meeting_id": "85451723466",
+            "occurrences": [
+                {
+                    "occurrence_number": 235,
+                    "issue_number": 2015,
+                    "issue_title": "ACDE #235",
+                    "start_time": "2026-04-23T14:00:00Z",
+                },
+                {
+                    "occurrence_number": 236,
+                    "issue_number": 2033,
+                    "issue_title": "ACDE #236",
+                    "start_time": "2026-05-07T14:00:00Z",
+                },
+                {
+                    "occurrence_number": 238,
+                    "issue_number": 2050,
+                    "issue_title": "ACDE #238",
+                    "start_time": "2026-06-04T14:00:00Z",
+                },
+            ],
+        }
+    }
+
+    candidates = select_occurrence_candidates(
+        mapping,
+        "acde",
+        now=datetime(2026, 5, 21, tzinfo=timezone.utc),
+    )
+
+    assert [candidate.issue_number for candidate in candidates] == [2033, 2015]
+    assert candidates[0].meeting_id == "85451723466"
+
+
+def test_select_occurrence_candidates_can_target_number():
+    mapping = {
+        "acde": {
+            "meeting_id": "85451723466",
+            "occurrences": [
+                {"occurrence_number": 235, "issue_number": 2015, "start_time": "2026-04-23T14:00:00Z"},
+                {"occurrence_number": 236, "issue_number": 2033, "start_time": "2026-05-07T14:00:00Z"},
+            ],
+        }
+    }
+
+    candidates = select_occurrence_candidates(mapping, "acde", number=235)
+
+    assert len(candidates) == 1
+    assert candidates[0].issue_number == 2015
+
+
+def test_build_ffmpeg_command_splits_bumper_and_reencodes():
+    command = build_ffmpeg_command(
+        Path("ev.mp4"),
+        Path("zoom.mp4"),
+        Path("out.mp4"),
+        bumper_duration=318.8,
+    )
+
+    command_text = " ".join(command)
+
+    assert command[:6] == ["ffmpeg", "-y", "-hide_banner", "-i", "ev.mp4", "-i"]
+    assert "trim=start=0:end=159.400000" in command_text
+    assert "trim=start=159.400000:end=318.800000" in command_text
+    assert "concat=n=3:v=1:a=1" in command_text
+    assert "libx264" in command
+    assert "+faststart" in command

--- a/.github/workflows/acd-video-sandwich-test.yml
+++ b/.github/workflows/acd-video-sandwich-test.yml
@@ -1,0 +1,107 @@
+name: ACD Video Sandwich Test
+
+on:
+  pull_request:
+    paths:
+      - ".github/ACDbot/scripts/compose_zoom_sandwich.py"
+      - ".github/ACDbot/tests/unit/test_compose_zoom_sandwich.py"
+      - ".github/workflows/acd-video-sandwich-test.yml"
+      - ".github/actions/setup-acdbot/action.yml"
+      - ".github/ACDbot/pyproject.toml"
+      - ".github/ACDbot/uv.lock"
+  workflow_dispatch:
+    inputs:
+      SERIES:
+        description: "Call series to test"
+        required: false
+        default: "acde"
+        type: string
+      NUMBER:
+        description: "Optional public occurrence number, e.g. 236"
+        required: false
+        type: string
+      BUMPER_URL:
+        description: "Optional URL for ev.mp4; falls back to ACD_BUMPER_URL variable/secret"
+        required: false
+        type: string
+
+jobs:
+  stitch:
+    name: Download latest ACDE Zoom recording and stitch
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 90
+
+    env:
+      SERIES: ${{ inputs.SERIES || 'acde' }}
+      NUMBER: ${{ inputs.NUMBER }}
+      BUMPER_URL: ${{ inputs.BUMPER_URL || vars.ACD_BUMPER_URL || secrets.ACD_BUMPER_URL }}
+      ZOOM_CLIENT_ID: ${{ secrets.ZOOM_CLIENT_ID }}
+      ZOOM_CLIENT_SECRET: ${{ secrets.ZOOM_CLIENT_SECRET }}
+      ZOOM_REFRESH_TOKEN: ${{ secrets.ZOOM_REFRESH_TOKEN }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up ACDbot
+        uses: ./.github/actions/setup-acdbot
+
+      - name: Install ffmpeg
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+
+      - name: Validate required configuration
+        run: |
+          missing=()
+          for name in BUMPER_URL ZOOM_CLIENT_ID ZOOM_CLIENT_SECRET ZOOM_REFRESH_TOKEN; do
+            if [ -z "${!name}" ]; then
+              missing+=("$name")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required configuration: ${missing[*]}"
+            echo "::error::Set ACD_BUMPER_URL to a downloadable ev.mp4 URL and ensure Zoom OAuth secrets are available."
+            exit 1
+          fi
+
+      - name: Download bumper
+        run: |
+          mkdir -p "${RUNNER_TEMP}/acd-video"
+          curl --fail --location --retry 3 --retry-delay 5 "$BUMPER_URL" --output "${RUNNER_TEMP}/acd-video/ev.mp4"
+          ffprobe -v error -show_entries format=duration,size -of json "${RUNNER_TEMP}/acd-video/ev.mp4"
+
+      - name: Compose sandwich
+        run: |
+          args=(
+            --series "$SERIES"
+            --bumper "${RUNNER_TEMP}/acd-video/ev.mp4"
+            --output "${RUNNER_TEMP}/acd-video/acd-sandwich.mp4"
+            --metadata "${RUNNER_TEMP}/acd-video/metadata.json"
+            --min-duration 10
+            --max-candidates 5
+          )
+
+          if [ -n "$NUMBER" ]; then
+            args+=(--number "$NUMBER")
+          fi
+
+          uv run --project "${GITHUB_WORKSPACE}/.github/ACDbot" --locked \
+            "${GITHUB_WORKSPACE}/.github/ACDbot/scripts/compose_zoom_sandwich.py" "${args[@]}"
+
+      - name: Upload stitched video
+        uses: actions/upload-artifact@v7
+        with:
+          path: ${{ runner.temp }}/acd-video/acd-sandwich.mp4
+          retention-days: 3
+          archive: false
+
+      - name: Upload stitch metadata
+        uses: actions/upload-artifact@v7
+        with:
+          name: acd-video-sandwich-metadata
+          path: ${{ runner.temp }}/acd-video/metadata.json
+          retention-days: 3
+          compression-level: 0


### PR DESCRIPTION
Closed in favor of a same-repository branch PR so the secret-backed GitHub Actions stitch test can run on pull_request.