### PR TITLE
Add trusted protocol call workflow contributor

### DIFF
--- a/.github/workflows/protocol-call-workflow.yml
+++ b/.github/workflows/protocol-call-workflow.yml
@@ -48,7 +48,7 @@ jobs:
               "samwilsn", "shemnon", "nixorokish", "dcrapis", "gabrocheleau",
               "joshdavislight", "nerolation", "jihoonsong", "bomanaps", "misilva73",
               "zsfelfoldi", "kevaundray", "jflo", "gcolvin", "asanso", "mkalinin",
-              "tcoratger", "kamilsa", "ladidan"
+              "tcoratger", "kamilsa", "ladidan", "dionysuzx"
             ];
 
             console.log(`Checking membership for user: ${username}`);


### PR DESCRIPTION
Summary:
- Add dionysuzx to the protocol call workflow trusted contributor fallback list.
- Allows issue edits from this account to pass the workflow membership gate when org membership is not visible to the Actions token.

Validation:
- Confirmed the workflow file contains the trusted contributor entry.