### PR TITLE
Accept stale Zoom recording topics for mapped calls

### DIFF
--- a/.github/ACDbot/scripts/asset_pipeline/download_zoom_assets.py
+++ b/.github/ACDbot/scripts/asset_pipeline/download_zoom_assets.py
@@ -108,7 +108,12 @@ def find_occurrence_by_date_series_and_number(date_str, series_name, mapping_man
 
 
 def choose_recording(candidates, series_name, expected_number=None):
-    """Choose one recording candidate without guessing across ambiguous calls."""
+    """Choose one recording candidate without guessing across ambiguous calls.
+
+    The mapped occurrence is the source of truth for the public call number.
+    Zoom recording topics can retain stale recurring-meeting titles, so a
+    single date-matched candidate is accepted even when its topic number is old.
+    """
     if not candidates:
         return None, None
 
@@ -127,8 +132,15 @@ def choose_recording(candidates, series_name, expected_number=None):
         if len(candidates) == 1 and len(unnumbered_candidates) == 1:
             return unnumbered_candidates[0]
         if len(candidates) == 1:
-            print(f"   ❌ Recording topic does not match expected {series_name} #{expected_number}")
-            return None, None
+            _, recording_data = candidates[0]
+            topic = recording_data.get('topic', '')
+            print(
+                f"   ⚠️  Recording topic does not match expected {series_name} #{expected_number}; "
+                f"using mapped occurrence because it is the only candidate"
+            )
+            if topic:
+                print(f"      Zoom topic: {topic}")
+            return candidates[0]
 
         print(f"   ❌ Ambiguous recordings for {series_name} #{expected_number}; refusing to guess")
         return None, None

--- a/.github/ACDbot/tests/unit/test_asset_pipeline_identity.py
+++ b/.github/ACDbot/tests/unit/test_asset_pipeline_identity.py
@@ -302,7 +302,7 @@ def test_requested_number_selects_matching_same_day_occurrence(tmp_path, monkeyp
     assert not (artifacts_dir / "sample" / "2025-05-19_037").exists()
 
 
-def test_expected_number_rejects_single_recording_with_wrong_topic_number(tmp_path, monkeypatch):
+def test_expected_number_accepts_single_recording_with_stale_topic_number(tmp_path, monkeypatch):
     download_zoom_assets = load_asset_pipeline_module("download_zoom_assets")
 
     mapping_path = tmp_path / "meeting_topic_mapping.json"
@@ -331,7 +331,7 @@ def test_expected_number_rejects_single_recording_with_wrong_topic_number(tmp_pa
     monkeypatch.setattr(
         download_zoom_assets,
         "download_file",
-        lambda *args, **kwargs: pytest.fail("wrong-number recording must not be downloaded"),
+        lambda url, token, path: path.write_text(url, encoding="utf-8") > 0,
     )
 
     download_zoom_assets.process_meeting_by_date(
@@ -342,7 +342,10 @@ def test_expected_number_rejects_single_recording_with_wrong_topic_number(tmp_pa
         requested_number=38,
     )
 
-    assert not (artifacts_dir / "sample").exists()
+    assert (artifacts_dir / "sample" / "2025-05-19_038" / "chat.txt").exists()
+    assert (
+        artifacts_dir / "sample" / "2025-05-19_038" / "chat.txt"
+    ).read_text(encoding="utf-8") == "https://example.test/sample-37-chat.txt"
 
 
 def test_summary_generation_uses_directory_number_for_same_day_occurrences(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

This updates Zoom asset ingestion so mapped occurrences use the GitHub meeting mapping as the canonical call identity when Zoom returns a stale recording topic. If a mapped date has exactly one recording candidate, the pipeline now accepts it and logs a warning instead of rejecting the recording solely because the Zoom topic has an old call number. Ambiguous multi-recording cases still refuse to guess.

## Why

Zoom completed recordings can retain an older recurring-meeting topic even after the meeting or occurrence title is corrected. The asset pipeline was treating that topic as a hard identity check, which prevented valid recordings from being written to the mapped artifact directory.

## Validation

- `uv run --project .github/ACDbot --locked pytest .github/ACDbot/tests/unit/test_asset_pipeline_identity.py`
- `uv run --project .github/ACDbot --locked pytest .github/ACDbot/tests/unit`