### PR TITLE
Match Zoom asset recordings by occurrence start time

### DIFF
--- a/.github/ACDbot/scripts/asset_pipeline/download_zoom_assets.py
+++ b/.github/ACDbot/scripts/asset_pipeline/download_zoom_assets.py
@@ -11,6 +11,7 @@ import json
 import sys
 import traceback
 from collections import defaultdict
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import requests
@@ -150,6 +151,45 @@ def choose_recording(candidates, series_name, expected_number=None):
 
     print(f"   ❌ Ambiguous recordings for {series_name}; refusing to choose by duration alone")
     return None, None
+
+
+def parse_utc_datetime(value):
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+
+
+def filter_candidates_by_occurrence_start(candidates, occurrence, tolerance_minutes=30):
+    """Keep recordings near the mapped occurrence start time when possible."""
+    if not candidates or not occurrence:
+        return candidates
+
+    target_start = parse_utc_datetime(occurrence.get("start_time"))
+    if not target_start:
+        return candidates
+
+    tolerance = timedelta(minutes=tolerance_minutes)
+    matching_candidates = []
+
+    for instance, recording_data in candidates:
+        start_time = instance.get("start_time") or recording_data.get("start_time")
+        candidate_start = parse_utc_datetime(start_time)
+        if candidate_start and abs(candidate_start - target_start) <= tolerance:
+            matching_candidates.append((instance, recording_data))
+
+    if matching_candidates:
+        skipped = len(candidates) - len(matching_candidates)
+        if skipped:
+            print(
+                f"   📍 Filtered out {skipped} same-day recording(s) outside "
+                f"{tolerance_minutes} minutes of mapped start time"
+            )
+        return matching_candidates
+
+    return candidates
 
 
 def download_assets_for_meeting(
@@ -386,6 +426,7 @@ def process_recent_meetings(
                         candidates.append((instance, recording_data))
 
         expected_number = get_occurrence_call_number(occurrence)
+        candidates = filter_candidates_by_occurrence_start(candidates, occurrence)
         best_instance, best_recording = choose_recording(candidates, series_name, expected_number)
         if best_recording and best_instance:
             print(f"   🎯 Selected recording for {date}: {best_recording.get('duration', 0)} minutes")
@@ -489,7 +530,7 @@ def process_meeting_by_date(
                     print(f"   ❌ No recording data found")
 
     _, matching_recording = choose_recording(
-        candidates,
+        filter_candidates_by_occurrence_start(candidates, occurrence),
         series_name,
         get_occurrence_call_number(occurrence),
     )

--- a/.github/ACDbot/tests/unit/test_asset_pipeline_identity.py
+++ b/.github/ACDbot/tests/unit/test_asset_pipeline_identity.py
@@ -348,6 +348,83 @@ def test_expected_number_accepts_single_recording_with_stale_topic_number(tmp_pa
     ).read_text(encoding="utf-8") == "https://example.test/sample-37-chat.txt"
 
 
+def test_asset_download_filters_same_day_recordings_by_mapped_start_time(tmp_path, monkeypatch):
+    download_zoom_assets = load_asset_pipeline_module("download_zoom_assets")
+
+    mapping_path = tmp_path / "meeting_topic_mapping.json"
+    artifacts_dir = tmp_path / "artifacts"
+    mapping_path.write_text(
+        json.dumps(
+            {
+                "sample": {
+                    "meeting_id": "84600001111",
+                    "occurrences": [
+                        {
+                            "issue_number": 1038,
+                            "issue_title": "Sample Call #38 | May 19 2025",
+                            "start_time": "2025-05-19T14:00:00Z",
+                        },
+                    ],
+                },
+            },
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(download_zoom_assets, "MAPPING_FILE_PATH", mapping_path)
+    monkeypatch.setattr(download_zoom_assets, "ARTIFACTS_DIR", artifacts_dir)
+    monkeypatch.setattr(
+        download_zoom_assets.zoom,
+        "get_past_meeting_instances",
+        lambda meeting_id: [
+            {"uuid": "near-recording", "start_time": "2025-05-19T14:02:00Z"},
+            {"uuid": "later-recording", "start_time": "2025-05-19T18:00:00Z"},
+        ],
+    )
+
+    recordings = {
+        "near-recording": {
+            "uuid": "near-recording",
+            "start_time": "2025-05-19T14:02:00Z",
+            "duration": 54,
+            "topic": "Sample Call #38 | May 19 2025",
+            "recording_files": [
+                {"file_type": "CHAT", "download_url": "https://example.test/near-chat.txt"},
+            ],
+        },
+        "later-recording": {
+            "uuid": "later-recording",
+            "start_time": "2025-05-19T18:00:00Z",
+            "duration": 55,
+            "topic": "Sample Call #38 | May 19 2025",
+            "recording_files": [
+                {"file_type": "CHAT", "download_url": "https://example.test/later-chat.txt"},
+            ],
+        },
+    }
+    monkeypatch.setattr(
+        download_zoom_assets.zoom,
+        "get_meeting_recording",
+        lambda uuid: recordings[uuid],
+    )
+    monkeypatch.setattr(
+        download_zoom_assets,
+        "download_file",
+        lambda url, token, path: path.write_text(url, encoding="utf-8") > 0,
+    )
+
+    download_zoom_assets.process_meeting_by_date(
+        "sample",
+        "2025-05-19",
+        "test-token",
+        min_duration_minutes=10,
+        requested_number=38,
+    )
+
+    chat_path = artifacts_dir / "sample" / "2025-05-19_038" / "chat.txt"
+    assert chat_path.exists()
+    assert chat_path.read_text(encoding="utf-8") == "https://example.test/near-chat.txt"
+
+
 def test_summary_generation_uses_directory_number_for_same_day_occurrences(tmp_path, monkeypatch):
     generate_summary = load_asset_pipeline_module("generate_summary")
 


### PR DESCRIPTION
## Summary
- filter same-day Zoom recording candidates to the mapped occurrence start-time window before choosing a recording
- keep the existing mapped call-number checks after time filtering
- add a regression test for multiple valid recordings on the same date

## Tests
- uv run --project .github/ACDbot --locked pytest .github/ACDbot/tests/unit/test_asset_pipeline_identity.py
- uv run --project .github/ACDbot --locked pytest .github/ACDbot/tests/unit