### PR TITLE
Reset PQTS YouTube upload state

### DIFF
--- a/.github/ACDbot/meeting_topic_mapping.json
+++ b/.github/ACDbot/meeting_topic_mapping.json
@@ -6811,16 +6811,15 @@
         "duration": 60,
         "skip_youtube_upload": false,
         "skip_transcript_processing": false,
-        "youtube_upload_processed": true,
+        "youtube_upload_processed": false,
         "transcript_processed": true,
-        "upload_attempt_count": 4,
+        "upload_attempt_count": 0,
         "transcript_attempt_count": 0,
         "telegram_message_id": null,
         "youtube_streams_posted_to_discourse": false,
         "youtube_streams": null,
         "occurrence_number": 9,
-        "discourse_topic_id": 28618,
-        "youtube_video_id": "_TgkYHj0K-c"
+        "discourse_topic_id": 28618
       }
     ],
     "duration": 60,


### PR DESCRIPTION
## Summary
- reopen the PQTS occurrence for YouTube upload after the bad video was removed
- remove the stale YouTube video id so the upload workflow can write the replacement id
- reset the upload attempt counter for this occurrence only

## Validation
- `uv run --project .github/ACDbot --locked python -m json.tool .github/ACDbot/meeting_topic_mapping.json >/dev/null`
- `git diff --check`