### PR TITLE
Rebase protocol call mapping commits before push

### DIFF
--- a/.github/workflows/protocol-call-workflow.yml
+++ b/.github/workflows/protocol-call-workflow.yml
@@ -239,6 +239,7 @@ jobs:
           else
             git add .github/ACDbot/meeting_topic_mapping.json
             git commit -m "Update mapping for issue $ISSUE_NUMBER"
+            git pull --rebase
             git push
             echo "Committed mapping file changes"
           fi


### PR DESCRIPTION
## Summary
- Rebase generated protocol-call mapping commits before pushing.
- Matches the existing asset pipeline commit flow so workflow reruns do not fail when master advances during a run.

## Testing
- actionlint not installed locally; workflow change is a single shell command already used by the asset pipeline.