### PR TITLE
acdbot: mirror EIP-8148 PFI decision into ACDC 179 tldr

### DIFF
--- a/.github/ACDbot/artifacts/acdc/2026-05-28_179/tldr.json
+++ b/.github/ACDbot/artifacts/acdc/2026-05-28_179/tldr.json
@@ -87,6 +87,10 @@
   ],
   "decisions": [
     {
+      "timestamp": "00:38:09",
+      "decision": "EIP-8148 (custom sweep threshold for validators) presented and proposed for Hegota (PFI); clients to review details before next ACDC"
+    },
+    {
       "timestamp": "00:29:07",
       "decision": "Adopt Marius's SSZ engine API PR (#793) over Barnabas's (#764); faster JSON-RPC deprecation path at Hegota"
     },


### PR DESCRIPTION
Companion to ethereum/forkcast#298, which records EIP-8148's PFI for Hegota at ACDC 179 (decisions + EIP fork history).

This mirrors the one new decisions entry into the upstream `tldr.json` so a future `sync-call-assets` run doesn't overwrite it on the Forkcast side — keeping the two copies byte-identical.

- `tldr.json` — add `EIP-8148 → proposed for Hegota (PFI)` to the `decisions` array (timestamp `00:38:09`).

(The `key_decisions.json` and EIP data live only in Forkcast, so there's nothing to mirror for those.)