### PR TITLE
Add BPO folder to Network-Upgrade-Archive

### DIFF
--- a/Network-Upgrade-Archive/BPO/bpo1.md
+++ b/Network-Upgrade-Archive/BPO/bpo1.md
@@ -20,3 +20,14 @@ These shared references apply to every BPO entry in this archive and are not rep
 - **Meta EIP:** [EIP-8134: Hardfork Meta - BPO1](https://eips.ethereum.org/EIPS/eip-8134) — parameters, activation time, base fee update fraction.
 - **Significance:** First mainnet exercise of the EIP-7892 mechanism. Establishes the precedent for config-only forks between major network upgrades and produces the first empirical data on whether the mechanism functions as designed at the coordination layer.
 - **Predecessor blob schedule:** Inherits from the Prague blob configuration set at the Pectra upgrade. See [EIP-7607: Hardfork Meta - Fusaka](https://eips.ethereum.org/EIPS/eip-7607) for the immediately preceding upgrade context.
+
+## BPO1 activation across networks
+
+Historical record of BPO1 activation on each network. Mainnet activation parameters are also recorded in [EIP-8134](https://eips.ethereum.org/EIPS/eip-8134); per-network testnet activations are recorded in [EIP-7606](https://eips.ethereum.org/EIPS/eip-8134), added here for quick reference:
+
+| Network Name | Activation Epoch | Activation Timestamp | Activation Time (UTC) | Fork ID      |
+| ------------ | ---------------- | -------------------- | --------------------- | ------------ |
+| Holešky      | 166400           | 1759800000           | 2025-10-07 01:20:00   | 0xa280a45c   |
+| Sepolia      | 274176           | 1761017184           | 2025-10-21 03:26:24   | 0x56078a1e   |
+| Hoodi        | 52480            | 1762365720           | 2025-11-05 18:02:00   | 0x3893353e   |
+| Mainnet      | 412672           | 1765290071           | 2025-12-09 14:21:11   | 0xcba2a1c0   |

--- a/Network-Upgrade-Archive/BPO/bpo1.md
+++ b/Network-Upgrade-Archive/BPO/bpo1.md
@@ -1,0 +1,22 @@
+# BPO1 — Blob-Parameter-Only Upgrade #1 (Mainnet)
+
+BPO1 is the **first** mainnet Blob-Parameter-Only (BPO) upgrade, deployed as a config-only fork following the Fusaka network upgrade. It establishes the BPO mechanism on mainnet and provides the initial incremental increase in blob capacity after PeerDAS activation.
+
+The BPO mechanism itself is specified in [EIP-7892: Blob Parameter Only Hardforks](https://eips.ethereum.org/EIPS/eip-7892). BPO upgrades modify only blob-related parameters; no other protocol behavior is affected.
+
+## About BPO upgrades (shared context for all BPO entries)
+
+- **Scope:** Only blob target, blob max, and the base fee update fraction change. Nothing else.
+- **Source of truth for runtime values:** [`eth-clients/mainnet/metadata/genesis.json`](https://github.com/eth-clients/mainnet/blob/main/metadata/genesis.json) (`bpoNTime` and `blobSchedule` fields).
+- **Coordination notes** (activation slots, epochs, fork IDs across all testnets and mainnet; client readiness; cell-level optimization status):
+  - [Fusaka & BPO timelines](https://notes.ethereum.org/@bbusa/fusaka-bpo-timeline)
+  - [Blob scaling in 2026](https://notes.ethereum.org/@ethpandaops/blob-scaling-2026)
+  - [Fusaka Mainnet Announcement](https://blog.ethereum.org/2025/11/06/fusaka-mainnet-announcement)
+
+These shared references apply to every BPO entry in this archive and are not repeated in subsequent BPO files.
+
+## BPO1-specific references
+
+- **Meta EIP:** [EIP-8134: Hardfork Meta - BPO1](https://eips.ethereum.org/EIPS/eip-8134) — parameters, activation time, base fee update fraction.
+- **Significance:** First mainnet exercise of the EIP-7892 mechanism. Establishes the precedent for config-only forks between major network upgrades and produces the first empirical data on whether the mechanism functions as designed at the coordination layer.
+- **Predecessor blob schedule:** Inherits from the Prague blob configuration set at the Pectra upgrade. See [EIP-7607: Hardfork Meta - Fusaka](https://eips.ethereum.org/EIPS/eip-7607) for the immediately preceding upgrade context.

--- a/Network-Upgrade-Archive/BPO/bpo2.md
+++ b/Network-Upgrade-Archive/BPO/bpo2.md
@@ -1,0 +1,28 @@
+# BPO2 — Blob-Parameter-Only Upgrade #2 (Mainnet)
+
+BPO2 is the **second** mainnet Blob-Parameter-Only (BPO) upgrade, deployed approximately one month after [BPO1](./bpo1.md). It continues the staged expansion of blob capacity under [EIP-7892](https://eips.ethereum.org/EIPS/eip-7892) following the Fusaka upgrade.
+
+For shared BPO context (mechanism scope, source-of-truth runtime configuration, coordination notes, and timeline references), see [bpo1.md](./bpo1.md).
+
+## BPO2-specific references
+
+- **Meta EIP:** [EIP-8135: Hardfork Meta - BPO2](https://eips.ethereum.org/EIPS/eip-8135) — parameters, activation time, base fee update fraction.
+- **Predecessor:** Builds directly on the parameter set introduced by [BPO1](./bpo1.md) / [EIP-8134](https://eips.ethereum.org/EIPS/eip-8134).
+
+## Post-deployment analysis
+
+Unlike BPO1, BPO2 has been the subject of dedicated empirical study because it is the first BPO to push the network into a parameter regime where blob counts can exceed the pre-Fusaka maximum:
+
+- [Blob Analysis after Fusaka and BPO Updates](https://ethresear.ch/t/blob-analysis-after-fusaka-and-bpo-updates/23853) — MigaLabs study of blob throughput and slot stability after BPO2 activation. Findings include observed capacity underutilization and missed-slot correlation at high blob counts, with a follow-up at the 100-day mark showing the early instability had been mitigated by client-side improvements.
+
+This analysis is the primary feedback signal informing whether additional BPO upgrades should be scheduled.
+
+## BPO2 activation across networks
+
+Historical record of BPO2 activation on each network. Mainnet activation parameters are also recorded in [EIP-8135](https://eips.ethereum.org/EIPS/eip-8135); per-network testnet activations are recorded in [EIP-7606](https://eips.ethereum.org/EIPS/eip-7607), added here for quick reference:
+| Network Name | Activation Epoch | Activation Timestamp | Activation Time (UTC) | Fork ID      |
+| ------------ | ---------------- | -------------------- | --------------------- | ------------ |
+| Holešky      | 167936           | 1760389824           | 2025-10-13 21:10:24   | 0x9bc6cb31   |
+| Sepolia      | 275712           | 1761607008           | 2025-10-27 23:16:48   | 0x268956b6   |
+| Hoodi        | 54016            | 1762955544           | 2025-11-12 13:52:24   | 0x23aa1351   |
+| Mainnet      | 419072           | 1767747671           | 2026-01-07 01:01:11   | 0x07c9462e   |


### PR DESCRIPTION
## Add BPO1 and BPO2 entries to Network-Upgrade-Archive

This PR adds lightweight archive entries for the two mainnet Blob-Parameter-Only (BPO) upgrades that followed Fusaka:

- `Network-Upgrade-Archive/BPO/bpo1.md` — activated 2025-12-09
- `Network-Upgrade-Archive/BPO/bpo2.md` — activated 2026-01-07

### Why a `BPO/` subfolder

Following the existing convention in this directory (e.g. `Fusaka/`), BPO entries are grouped under a single subfolder rather than placed as loose files at the archive root. This:

- keeps related entries co-located so future BPO upgrades drop in without restructuring,
- lets `bpo2.md` reference shared context in `bpo1.md` via a stable relative link, and
- leaves room for a `README.md` index in the folder later if useful.

Happy to instead nest these under `Fusaka/BPO/` if the maintainers prefer treating BPO upgrades as children of their parent network upgrade rather than as peer entries.

### Why these files are intentionally lightweight

The parameter values, activation timestamps, blob target/max, and base fee update fraction for each BPO are already canonically recorded in various places:

1. **Meta EIPs** —  [EIP-7607 (Fusaka)](https://eips.ethereum.org/EIPS/eip-7607), [EIP-8134 (BPO1)](https://eips.ethereum.org/EIPS/eip-8134) and [EIP-8135 (BPO2)](https://eips.ethereum.org/EIPS/eip-8135)
2. **Execution client chain configuration** — `eth-clients/mainnet/metadata/genesis.json` (the actual runtime source of truth)

Duplicating those values here would create another copy that can drift out of sync with the others. Instead, these archive entries link to the canonical sources and only carry what is specific to the archive context: the role of each upgrade in the BPO sequence, links to coordination notes ([Fusaka & BPO timelines](https://notes.ethereum.org/@bbusa/fusaka-bpo-timeline), [Blob scaling in 2026](https://notes.ethereum.org/@ethpandaops/blob-scaling-2026)), and post-deployment analysis ([MigaLabs ethresear.ch study](https://ethresear.ch/t/blob-analysis-after-fusaka-and-bpo-updates/23853)). The only duplicated information is the `per-network testnet activation data`, which is canonically maintained in [EIP-7606](https://eips.ethereum.org/EIPS/eip-7607) and included in the related .md files solely for convenience and quick reference.

### Why are the two files not symmetric

`bpo1.md` carries the shared context that applies to every BPO entry (mechanism scope per [EIP-7892](https://eips.ethereum.org/EIPS/eip-7892), source-of-truth locations, coordination references). `bpo2.md` does not repeat any of this — it references `bpo1.md` for shared context and only adds what is specific to BPO2: its Meta EIP, its relationship to BPO1, and the post-deployment empirical study (which is BPO2-specific because BPO2 is the first BPO that pushed mainnet past the pre-Fusaka blob ceiling and produced enough data to study).

Future BPO entries can follow the same pattern: link back to `bpo1.md` for shared context and document only what is new.

### Review focus

The substantive questions for reviewers are:

1. Placement: `Network-Upgrade-Archive/BPO/` vs `Network-Upgrade-Archive/Fusaka/BPO/` vs files at the archive root.
2. Whether the "shared context lives in `bpo1.md`, deltas only in subsequent files" pattern is acceptable, or whether each entry should be self-contained even at the cost of some duplication.
3. Whether any link target should change (in particular, the relative link to `bpo-blob-schedule.md` once that file lands in its canonical location in `ethereum/pm`).