### PR TITLE
Add autonomous ACDT recording pipeline

### DIFF
--- a/.github/ACDbot/call_series_config.yml
+++ b/.github/ACDbot/call_series_config.yml
@@ -64,11 +64,10 @@ call_series:
     display_name: "All Core Devs - Testing"
     youtube_playlist_id: "PLJqWcTqh_zKFE51VgNZmgT5SGYTKnyY6Y"
     discord_webhook_env: "DISCORD_ACD_WEBHOOK"
-    recording_publication_mode: "composed_zoom_recording"
     autopilot_defaults:
       duration: 60
       occurrence_rate: "weekly"
-      need_youtube_streams: false
+      need_youtube_streams: true
       display_zoom_link_in_invite: true
       external_meeting_link: false
 

--- a/.github/ACDbot/call_series_config.yml
+++ b/.github/ACDbot/call_series_config.yml
@@ -16,6 +16,9 @@
 #     need_youtube_streams: Whether to create YouTube livestreams
 #     display_zoom_link_in_invite: Whether to show Zoom link in calendar invite
 #     external_meeting_link: Whether to use an external meeting link (skip Zoom creation)
+#   recording_publication_mode: How post-call recordings are uploaded to YouTube.
+#     raw_zoom_recording: Upload the selected Zoom MP4 directly.
+#     composed_zoom_recording: Compose bumper + Zoom recording + bumper with ffmpeg before upload.
 
 # Default autopilot settings used when a call series doesn't have specific configuration
 default_autopilot_settings:
@@ -61,10 +64,11 @@ call_series:
     display_name: "All Core Devs - Testing"
     youtube_playlist_id: "PLJqWcTqh_zKFE51VgNZmgT5SGYTKnyY6Y"
     discord_webhook_env: "DISCORD_ACD_WEBHOOK"
+    recording_publication_mode: "composed_zoom_recording"
     autopilot_defaults:
       duration: 60
       occurrence_rate: "weekly"
-      need_youtube_streams: true
+      need_youtube_streams: false
       display_zoom_link_in_invite: true
       external_meeting_link: false
 

--- a/.github/ACDbot/meeting_topic_mapping.json
+++ b/.github/ACDbot/meeting_topic_mapping.json
@@ -734,7 +734,7 @@
         "discourse_topic_id": 23392,
         "start_time": "2025-04-17T14:00:00Z",
         "duration": 90,
-        "skip_youtube_upload": false,
+        "skip_youtube_upload": true,
         "youtube_upload_processed": true,
         "transcript_processed": true,
         "upload_attempt_count": 9,
@@ -1777,7 +1777,15 @@
         "transcript_attempt_count": 0,
         "telegram_message_id": null,
         "youtube_streams_posted_to_discourse": false,
-        "youtube_streams": null,
+        "youtube_streams": [
+          {
+            "broadcast_id": "MldFzAj_yx8",
+            "stream_id": "6rYoXJ_3BbPyWx_GQDDRRQ1779900641180443",
+            "stream_url": "https://youtube.com/watch?v=MldFzAj_yx8",
+            "rtmp_url": "rtmp://a.rtmp.youtube.com/live2/kczf-wrzz-bda4-dx3y-f475",
+            "scheduled_time": "2026-06-01T14:00:00.000Z"
+          }
+        ],
         "occurrence_number": 19,
         "discourse_topic_id": 25250
       },

--- a/.github/ACDbot/meeting_topic_mapping.json
+++ b/.github/ACDbot/meeting_topic_mapping.json
@@ -1777,15 +1777,7 @@
         "transcript_attempt_count": 0,
         "telegram_message_id": null,
         "youtube_streams_posted_to_discourse": false,
-        "youtube_streams": [
-          {
-            "broadcast_id": "MldFzAj_yx8",
-            "stream_id": "6rYoXJ_3BbPyWx_GQDDRRQ1779900641180443",
-            "stream_url": "https://youtube.com/watch?v=MldFzAj_yx8",
-            "rtmp_url": "rtmp://a.rtmp.youtube.com/live2/kczf-wrzz-bda4-dx3y-f475",
-            "scheduled_time": "2026-06-01T14:00:00.000Z"
-          }
-        ],
+        "youtube_streams": null,
         "occurrence_number": 19,
         "discourse_topic_id": 25250
       },
@@ -2538,7 +2530,7 @@
         "issue_title": "All Core Devs - Testing (ACDT) #81, June 1, 2026",
         "start_time": "2026-06-01T14:00:00Z",
         "duration": 60,
-        "skip_youtube_upload": false,
+        "skip_youtube_upload": true,
         "skip_transcript_processing": false,
         "youtube_upload_processed": false,
         "transcript_processed": false,
@@ -2546,7 +2538,15 @@
         "transcript_attempt_count": 0,
         "telegram_message_id": null,
         "youtube_streams_posted_to_discourse": false,
-        "youtube_streams": null,
+        "youtube_streams": [
+          {
+            "broadcast_id": "MldFzAj_yx8",
+            "stream_id": "6rYoXJ_3BbPyWx_GQDDRRQ1779900641180443",
+            "stream_url": "https://youtube.com/watch?v=MldFzAj_yx8",
+            "rtmp_url": "rtmp://a.rtmp.youtube.com/live2/kczf-wrzz-bda4-dx3y-f475",
+            "scheduled_time": "2026-06-01T14:00:00.000Z"
+          }
+        ],
         "occurrence_number": 49,
         "discourse_topic_id": 28643
       }

--- a/.github/ACDbot/meeting_topic_mapping.json
+++ b/.github/ACDbot/meeting_topic_mapping.json
@@ -2530,7 +2530,7 @@
         "issue_title": "All Core Devs - Testing (ACDT) #81, June 1, 2026",
         "start_time": "2026-06-01T14:00:00Z",
         "duration": 60,
-        "skip_youtube_upload": true,
+        "skip_youtube_upload": false,
         "skip_transcript_processing": false,
         "youtube_upload_processed": false,
         "transcript_processed": false,
@@ -2538,15 +2538,7 @@
         "transcript_attempt_count": 0,
         "telegram_message_id": null,
         "youtube_streams_posted_to_discourse": false,
-        "youtube_streams": [
-          {
-            "broadcast_id": "MldFzAj_yx8",
-            "stream_id": "6rYoXJ_3BbPyWx_GQDDRRQ1779900641180443",
-            "stream_url": "https://youtube.com/watch?v=MldFzAj_yx8",
-            "rtmp_url": "rtmp://a.rtmp.youtube.com/live2/kczf-wrzz-bda4-dx3y-f475",
-            "scheduled_time": "2026-06-01T14:00:00.000Z"
-          }
-        ],
+        "youtube_streams": null,
         "occurrence_number": 49,
         "discourse_topic_id": 28643
       }

--- a/.github/ACDbot/modules/call_series_config.py
+++ b/.github/ACDbot/modules/call_series_config.py
@@ -16,6 +16,7 @@ CONFIG_FILE_PATH = os.path.join(
 )
 
 _config_cache = None
+DEFAULT_RECORDING_PUBLICATION_MODE = "raw_zoom_recording"
 
 
 def _load_config() -> dict:
@@ -109,6 +110,20 @@ def get_call_series_config(series_key: str) -> Optional[dict]:
     """
     config = _load_config()
     return config.get("call_series", {}).get(series_key)
+
+
+def get_recording_publication_mode(series_key: str) -> str:
+    """
+    Get how recordings should be prepared before YouTube upload.
+
+    Args:
+        series_key: The call series key (e.g., "acdt")
+
+    Returns:
+        "raw_zoom_recording" unless the series config opts into another mode.
+    """
+    series_config = get_call_series_config(series_key) or {}
+    return series_config.get("recording_publication_mode") or DEFAULT_RECORDING_PUBLICATION_MODE
 
 
 def reload_config():

--- a/.github/ACDbot/scripts/compose_zoom_recording.py
+++ b/.github/ACDbot/scripts/compose_zoom_recording.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Compose a Zoom recording with fixed bumper clips.
+
+The production ACDT upload shape is:
+
+    first 45 seconds of bumper + Zoom recording + last 45 seconds of bumper
+
+Zoom access and ffmpeg execution stay at the edge. Selection and command
+construction are pure enough to keep covered by focused unit tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import requests
+
+
+PEAK_LEVEL_PATTERN = re.compile(r"Peak level dB:\s+(-inf|[-0-9.]+)")
+VTT_CUE_PATTERN = re.compile(
+    r"(?P<start>\d{2}:\d{2}:\d{2}\.\d{3}|\d{2}:\d{2}\.\d{3})\s+-->\s+"
+    r"(?P<end>\d{2}:\d{2}:\d{2}\.\d{3}|\d{2}:\d{2}\.\d{3})"
+)
+REQUIRED_VIDEO_LAYOUT = "shared_screen_with_speaker_view"
+DEFAULT_BUMPER_CLIP_SECONDS = 45.0
+
+
+@dataclass(frozen=True)
+class SelectedRecordingFiles:
+    video_file: dict[str, Any]
+    audio_file: dict[str, Any] | None
+    transcript_file: dict[str, Any] | None
+
+
+@dataclass(frozen=True)
+class ZoomTrimWindow:
+    start_seconds: float
+    end_seconds: float | None
+
+
+def probe_duration(path: Path) -> float:
+    command = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "json",
+        str(path),
+    ]
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    duration = float(json.loads(result.stdout)["format"]["duration"])
+    if duration <= 0:
+        raise ValueError(f"Could not determine a positive duration for {path}")
+    return duration
+
+
+def build_ffmpeg_command(
+    bumper_path: Path,
+    zoom_path: Path,
+    output_path: Path,
+    bumper_duration: float,
+    zoom_audio_path: Path | None = None,
+    zoom_trim: ZoomTrimWindow | None = None,
+    bumper_clip_seconds: float = DEFAULT_BUMPER_CLIP_SECONDS,
+    width: int = 1280,
+    height: int = 720,
+    fps: int = 30,
+) -> list[str]:
+    """Build the ffmpeg command for bumper intro + Zoom + bumper outro."""
+    if bumper_duration < bumper_clip_seconds * 2:
+        raise ValueError(
+            f"Bumper must be at least {bumper_clip_seconds * 2:.0f} seconds; "
+            f"got {bumper_duration:.3f}s"
+        )
+
+    outro_start = bumper_duration - bumper_clip_seconds
+    zoom_start = zoom_trim.start_seconds if zoom_trim else 0
+    zoom_end = zoom_trim.end_seconds if zoom_trim else None
+    zoom_video_trim = f"trim=start={zoom_start:.6f}"
+    zoom_audio_trim = f"atrim=start={zoom_start:.6f}"
+    if zoom_end is not None:
+        zoom_video_trim += f":end={zoom_end:.6f}"
+        zoom_audio_trim += f":end={zoom_end:.6f}"
+
+    video_normalize = (
+        f"scale={width}:{height}:force_original_aspect_ratio=decrease,"
+        f"pad={width}:{height}:(ow-iw)/2:(oh-ih)/2:color=black,"
+        f"setsar=1,fps={fps},format=yuv420p"
+    )
+    audio_normalize = "aformat=sample_fmts=fltp:sample_rates=48000:channel_layouts=stereo"
+    filter_complex = ";".join(
+        [
+            f"[0:v]trim=start=0:end={bumper_clip_seconds:.6f},setpts=PTS-STARTPTS,{video_normalize}[v0]",
+            f"[0:a]atrim=start=0:end={bumper_clip_seconds:.6f},asetpts=PTS-STARTPTS,{audio_normalize}[a0]",
+            f"[1:v]{zoom_video_trim},setpts=PTS-STARTPTS,{video_normalize}[v1]",
+            f"[{2 if zoom_audio_path else 1}:a]{zoom_audio_trim},asetpts=PTS-STARTPTS,{audio_normalize}[a1]",
+            f"[0:v]trim=start={outro_start:.6f}:end={bumper_duration:.6f},setpts=PTS-STARTPTS,{video_normalize}[v2]",
+            f"[0:a]atrim=start={outro_start:.6f}:end={bumper_duration:.6f},asetpts=PTS-STARTPTS,{audio_normalize}[a2]",
+            "[v0][a0][v1][a1][v2][a2]concat=n=3:v=1:a=1[v][a]",
+        ]
+    )
+
+    command = [
+        "ffmpeg",
+        "-y",
+        "-hide_banner",
+        "-i",
+        str(bumper_path),
+        "-i",
+        str(zoom_path),
+    ]
+    if zoom_audio_path:
+        command.extend(["-i", str(zoom_audio_path)])
+    command.extend(
+        [
+            "-filter_complex",
+            filter_complex,
+            "-map",
+            "[v]",
+            "-map",
+            "[a]",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryfast",
+            "-crf",
+            "23",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "160k",
+            "-movflags",
+            "+faststart",
+            str(output_path),
+        ]
+    )
+    return command
+
+
+def normalize_recording_type(recording_type: str) -> str:
+    """Treat Zoom's closed-caption variant as the same video layout."""
+    return recording_type.removesuffix("(CC)")
+
+
+def required_video_rank(file_info: dict[str, Any]) -> tuple[int, int]:
+    recording_type = file_info.get("recording_type", "")
+    is_not_caption_variant = int(recording_type != f"{REQUIRED_VIDEO_LAYOUT}(CC)")
+    return is_not_caption_variant, -(file_info.get("file_size") or 0)
+
+
+def select_recording_files(recording_info: dict[str, Any]) -> SelectedRecordingFiles | None:
+    recording_files = recording_info.get("recording_files", [])
+    video_files = [
+        file_info
+        for file_info in recording_files
+        if file_info.get("file_type") == "MP4" and file_info.get("download_url")
+    ]
+
+    if video_files:
+        available = ", ".join(
+            f"{file_info.get('recording_type', 'unknown')}:{file_info.get('file_size', 'unknown')}"
+            for file_info in video_files
+        )
+        print(f"[INFO] Available Zoom MP4 layouts: {available}")
+
+    required_video_files = [
+        file_info
+        for file_info in video_files
+        if normalize_recording_type(file_info.get("recording_type", "")) == REQUIRED_VIDEO_LAYOUT
+    ]
+    video_file = min(required_video_files, key=required_video_rank) if required_video_files else None
+    if video_file is None:
+        print(f"[WARN] Recording had no required MP4 video layout: {REQUIRED_VIDEO_LAYOUT}")
+        return None
+
+    print(
+        "[DEBUG] Selected required video layout: "
+        f"{video_file.get('recording_type', 'unknown')} size={video_file.get('file_size', 'unknown')}"
+    )
+
+    audio_candidates = [
+        file_info
+        for file_info in recording_files
+        if file_info.get("file_type") == "M4A" and file_info.get("download_url")
+    ]
+    audio_candidates.sort(key=lambda file_info: file_info.get("file_size") or 0, reverse=True)
+    audio_file = audio_candidates[0] if audio_candidates else None
+    if audio_file:
+        print(
+            "[DEBUG] Selected separate audio: "
+            f"{audio_file.get('recording_type', 'unknown')} size={audio_file.get('file_size', 'unknown')}"
+        )
+    else:
+        print("[WARN] No separate M4A audio found; using the MP4 audio track")
+
+    transcript_candidates = [
+        file_info
+        for file_info in recording_files
+        if file_info.get("file_type") == "TRANSCRIPT" and file_info.get("download_url")
+    ]
+    transcript_candidates.sort(key=lambda file_info: file_info.get("file_size") or 0, reverse=True)
+    transcript_file = transcript_candidates[0] if transcript_candidates else None
+    if transcript_file:
+        print(
+            "[DEBUG] Selected transcript: "
+            f"{transcript_file.get('recording_type', 'unknown')} size={transcript_file.get('file_size', 'unknown')}"
+        )
+    else:
+        print("[WARN] No Zoom transcript found; dead-air trimming will be skipped")
+
+    return SelectedRecordingFiles(video_file=video_file, audio_file=audio_file, transcript_file=transcript_file)
+
+
+def parse_vtt_timestamp(value: str) -> float:
+    parts = value.split(":")
+    if len(parts) == 2:
+        minutes, seconds = parts
+        return int(minutes) * 60 + float(seconds)
+    if len(parts) == 3:
+        hours, minutes, seconds = parts
+        return int(hours) * 3600 + int(minutes) * 60 + float(seconds)
+    raise ValueError(f"Unsupported VTT timestamp: {value}")
+
+
+def transcript_speech_window(
+    transcript_text: str,
+    duration_seconds: float,
+    padding_seconds: float = 10,
+) -> ZoomTrimWindow | None:
+    cue_times = [
+        (parse_vtt_timestamp(match.group("start")), parse_vtt_timestamp(match.group("end")))
+        for match in VTT_CUE_PATTERN.finditer(transcript_text)
+    ]
+    if not cue_times:
+        return None
+
+    first_start = min(start for start, _ in cue_times)
+    last_end = max(end for _, end in cue_times)
+    start_seconds = max(0, first_start - padding_seconds)
+    end_seconds = min(duration_seconds, last_end + padding_seconds)
+    if end_seconds <= start_seconds:
+        return None
+    return ZoomTrimWindow(start_seconds=start_seconds, end_seconds=end_seconds)
+
+
+def download_zoom_file(file_info: dict[str, Any], access_token: str, suffix: str) -> Path:
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    try:
+        with requests.get(file_info["download_url"], headers=headers, stream=True) as response:
+            if response.status_code != 200:
+                raise RuntimeError(f"Failed to download Zoom file: HTTP {response.status_code}")
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                if chunk:
+                    temp_file.write(chunk)
+    finally:
+        temp_file.close()
+
+    path = Path(temp_file.name)
+    print(f"[SUCCESS] Downloaded {suffix} to: {path} ({path.stat().st_size / 1024 / 1024:.1f} MiB)")
+    return path
+
+
+def extract_peak_level_db(ffmpeg_output: str) -> float | None:
+    peak_levels = []
+    for match in PEAK_LEVEL_PATTERN.finditer(ffmpeg_output):
+        value = match.group(1)
+        peak_levels.append(-math.inf if value == "-inf" else float(value))
+    finite_levels = [level for level in peak_levels if math.isfinite(level)]
+    return max(finite_levels) if finite_levels else None
+
+
+def audio_has_signal(path: Path, minimum_peak_db: float = -50.0) -> bool:
+    command = [
+        "ffmpeg",
+        "-hide_banner",
+        "-i",
+        str(path),
+        "-af",
+        "astats=metadata=1:reset=0",
+        "-f",
+        "null",
+        "-",
+    ]
+    result = subprocess.run(command, capture_output=True, text=True)
+    peak_level = extract_peak_level_db(result.stderr)
+    if peak_level is None:
+        print(f"[WARN] Could not measure audio signal for {path}")
+        return False
+
+    print(f"[INFO] Measured audio peak for {path}: {peak_level:.2f} dB")
+    return peak_level >= minimum_peak_db
+
+
+def compose_zoom_recording(
+    recording_info: dict[str, Any],
+    bumper_path: Path,
+    output_path: Path,
+    access_token: str,
+    bumper_clip_seconds: float = DEFAULT_BUMPER_CLIP_SECONDS,
+) -> Path | None:
+    """Download selected Zoom media and compose the final upload MP4."""
+    selected_files = select_recording_files(recording_info)
+    if not selected_files:
+        raise RuntimeError(
+            "Zoom recording exists but does not include required video layout "
+            f"{REQUIRED_VIDEO_LAYOUT}. Check the host's Zoom cloud recording settings."
+        )
+
+    zoom_path = download_zoom_file(selected_files.video_file, access_token, ".mp4")
+    zoom_audio_path = download_zoom_file(selected_files.audio_file, access_token, ".m4a") if selected_files.audio_file else None
+    zoom_transcript_path = (
+        download_zoom_file(selected_files.transcript_file, access_token, ".vtt")
+        if selected_files.transcript_file
+        else None
+    )
+
+    try:
+        audio_source = zoom_audio_path or zoom_path
+        if not audio_has_signal(audio_source):
+            print(f"[WARN] Rejecting silent Zoom recording candidate: {audio_source}")
+            return None
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        bumper_duration = probe_duration(bumper_path)
+        zoom_trim = None
+        if zoom_transcript_path:
+            zoom_duration = probe_duration(zoom_path)
+            zoom_trim = transcript_speech_window(
+                zoom_transcript_path.read_text(encoding="utf-8", errors="replace"),
+                duration_seconds=zoom_duration,
+            )
+            if zoom_trim:
+                print(
+                    "[INFO] Trimmed Zoom segment from transcript cues: "
+                    f"{zoom_trim.start_seconds:.3f}s to {zoom_trim.end_seconds:.3f}s"
+                )
+            else:
+                print("[WARN] Could not derive a transcript trim window; using full Zoom recording")
+
+        command = build_ffmpeg_command(
+            bumper_path,
+            zoom_path,
+            output_path,
+            bumper_duration,
+            zoom_audio_path,
+            zoom_trim,
+            bumper_clip_seconds=bumper_clip_seconds,
+        )
+
+        print(f"[INFO] Bumper duration: {bumper_duration:.3f}s")
+        if zoom_audio_path:
+            print(f"[INFO] Using separate Zoom audio: {zoom_audio_path}")
+        print(f"[INFO] Composing output: {output_path}")
+        subprocess.run(command, check=True)
+        print(f"[SUCCESS] Wrote {output_path} ({output_path.stat().st_size / 1024 / 1024:.1f} MiB)")
+        return output_path
+    finally:
+        for path in [zoom_path, zoom_audio_path, zoom_transcript_path]:
+            if not path:
+                continue
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Create a composed Zoom recording upload")
+    parser.add_argument("--recording-json", required=True, type=Path, help="Path to Zoom recording JSON")
+    parser.add_argument("--bumper", required=True, type=Path, help="Path to the bumper MP4")
+    parser.add_argument("--output", required=True, type=Path, help="Path for the composed MP4")
+    parser.add_argument("--bumper-clip-seconds", type=float, default=DEFAULT_BUMPER_CLIP_SECONDS)
+    args = parser.parse_args()
+
+    if not args.bumper.exists():
+        raise FileNotFoundError(f"Bumper file does not exist: {args.bumper}")
+
+    from modules.zoom import get_access_token
+
+    recording_info = json.loads(args.recording_json.read_text(encoding="utf-8"))
+    output = compose_zoom_recording(
+        recording_info,
+        args.bumper,
+        args.output,
+        get_access_token(),
+        bumper_clip_seconds=args.bumper_clip_seconds,
+    )
+    return 0 if output else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/ACDbot/scripts/compose_zoom_recording.py
+++ b/.github/ACDbot/scripts/compose_zoom_recording.py
@@ -20,10 +20,13 @@ import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 import requests
+
+from scripts.asset_pipeline.meeting_identity import get_occurrence_call_number
 
 
 PEAK_LEVEL_PATTERN = re.compile(r"Peak level dB:\s+(-inf|[-0-9.]+)")
@@ -33,6 +36,19 @@ VTT_CUE_PATTERN = re.compile(
 )
 REQUIRED_VIDEO_LAYOUT = "shared_screen_with_speaker_view"
 DEFAULT_BUMPER_CLIP_SECONDS = 45.0
+ACDBOT_DIR = Path(__file__).resolve().parents[1]
+MAPPING_FILE_PATH = ACDBOT_DIR / "meeting_topic_mapping.json"
+
+
+@dataclass(frozen=True)
+class OccurrenceRecordingTarget:
+    series: str
+    meeting_id: str
+    issue_number: int | None
+    number: int | None
+    title: str
+    start_time: str | None
+    duration_minutes: int | None
 
 
 @dataclass(frozen=True)
@@ -46,6 +62,64 @@ class SelectedRecordingFiles:
 class ZoomTrimWindow:
     start_seconds: float
     end_seconds: float | None
+
+
+def parse_utc_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def select_recording_target(
+    mapping: dict[str, Any],
+    series: str,
+    number: int | None = None,
+    max_age_days: int | None = None,
+    now: datetime | None = None,
+) -> OccurrenceRecordingTarget | None:
+    """Select one mapped occurrence to compose for test-artifact generation."""
+    series_entry = mapping.get(series)
+    if not series_entry:
+        raise ValueError(f"Series '{series}' was not found in {MAPPING_FILE_PATH}")
+
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=max_age_days) if max_age_days is not None else None
+    matches = []
+    for occurrence in series_entry.get("occurrences", []):
+        occurrence_number = get_occurrence_call_number(occurrence)
+        if number is not None and occurrence_number != number:
+            continue
+
+        start_dt = parse_utc_timestamp(occurrence.get("start_time"))
+        if number is None:
+            if start_dt and start_dt > now:
+                continue
+            if cutoff and start_dt and start_dt < cutoff:
+                continue
+
+        matches.append((start_dt or datetime.min.replace(tzinfo=timezone.utc), occurrence_number, occurrence))
+
+    if not matches:
+        return None
+    if number is not None and len(matches) > 1:
+        dates = ", ".join(occurrence.get("start_time", "unknown") for _, _, occurrence in matches)
+        raise ValueError(f"Ambiguous mapped occurrences for {series} #{number}: {dates}")
+
+    _, occurrence_number, occurrence = sorted(matches, key=lambda item: item[0], reverse=True)[0]
+    meeting_id = str(occurrence.get("meeting_id") or series_entry.get("meeting_id") or "").strip()
+    if not meeting_id:
+        raise ValueError(f"Mapped occurrence for {series} has no meeting_id")
+
+    issue_number = occurrence.get("issue_number")
+    return OccurrenceRecordingTarget(
+        series=series,
+        meeting_id=meeting_id,
+        issue_number=int(issue_number) if issue_number is not None else None,
+        number=occurrence_number,
+        title=occurrence.get("issue_title") or f"{series.upper()} recording",
+        start_time=occurrence.get("start_time"),
+        duration_minutes=occurrence.get("duration"),
+    )
 
 
 def probe_duration(path: Path) -> float:
@@ -378,20 +452,72 @@ def compose_zoom_recording(
                 pass
 
 
+def write_metadata(path: Path, target: OccurrenceRecordingTarget, output_path: Path | None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    metadata = {
+        "series": target.series,
+        "meeting_id": target.meeting_id,
+        "issue_number": target.issue_number,
+        "number": target.number,
+        "title": target.title,
+        "start_time": target.start_time,
+        "duration_minutes": target.duration_minutes,
+        "output_file": str(output_path) if output_path else None,
+        "output_size_bytes": output_path.stat().st_size if output_path and output_path.exists() else None,
+    }
+    path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Create a composed Zoom recording upload")
-    parser.add_argument("--recording-json", required=True, type=Path, help="Path to Zoom recording JSON")
+    parser.add_argument("--recording-json", type=Path, help="Path to Zoom recording JSON")
+    parser.add_argument("--series", help="Mapped call series to compose from Zoom")
+    parser.add_argument("--number", type=int, help="Optional public call number for --series")
     parser.add_argument("--bumper", required=True, type=Path, help="Path to the bumper MP4")
     parser.add_argument("--output", required=True, type=Path, help="Path for the composed MP4")
+    parser.add_argument("--metadata", type=Path, help="Optional metadata JSON output path")
     parser.add_argument("--bumper-clip-seconds", type=float, default=DEFAULT_BUMPER_CLIP_SECONDS)
+    parser.add_argument("--min-duration", type=int, default=10, help="Minimum Zoom recording duration in minutes")
+    parser.add_argument("--max-age-days", type=int, default=3, help="Recent target cutoff when --number is omitted")
     args = parser.parse_args()
 
     if not args.bumper.exists():
         raise FileNotFoundError(f"Bumper file does not exist: {args.bumper}")
+    if bool(args.recording_json) == bool(args.series):
+        raise ValueError("Pass exactly one of --recording-json or --series")
 
     from modules.zoom import get_access_token
 
-    recording_info = json.loads(args.recording_json.read_text(encoding="utf-8"))
+    target = None
+    if args.recording_json:
+        recording_info = json.loads(args.recording_json.read_text(encoding="utf-8"))
+    else:
+        from scripts.upload_zoom_recording import find_best_youtube_recording
+
+        mapping = json.loads(MAPPING_FILE_PATH.read_text(encoding="utf-8"))
+        target = select_recording_target(
+            mapping,
+            args.series,
+            args.number,
+            max_age_days=args.max_age_days,
+        )
+        if not target:
+            print(f"[SKIP] No recent mapped occurrence found for {args.series}")
+            return 0
+
+        target_min_duration = args.min_duration
+        if target.duration_minutes:
+            target_min_duration = max(args.min_duration, target.duration_minutes // 2)
+        recording_info = find_best_youtube_recording(
+            target.meeting_id,
+            min_duration_minutes=target_min_duration,
+            target_start_time=target.start_time,
+            tolerance_minutes=180,
+        )
+        if not recording_info:
+            print(f"[SKIP] No Zoom recording found yet for {target.series} #{target.number}")
+            return 0
+
     output = compose_zoom_recording(
         recording_info,
         args.bumper,
@@ -399,6 +525,8 @@ def main() -> int:
         get_access_token(),
         bumper_clip_seconds=args.bumper_clip_seconds,
     )
+    if args.metadata and target:
+        write_metadata(args.metadata, target, output)
     return 0 if output else 1
 
 

--- a/.github/ACDbot/scripts/upload_zoom_recording.py
+++ b/.github/ACDbot/scripts/upload_zoom_recording.py
@@ -13,6 +13,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from modules import zoom, transcript, discourse, tg, mattermost_notify
+from modules.call_series_config import get_recording_publication_mode
 from modules.youtube_utils import add_video_to_appropriate_playlist
 from modules.mapping_utils import (
     load_mapping as load_meeting_topic_mapping,
@@ -49,6 +50,9 @@ CLIENT_SECRETS_FILE = "client_secrets.json"
 
 # Thumbnail for uploaded recordings (distinct from livestream thumbnail)
 UPLOAD_THUMBNAIL_PATH = str(Path(__file__).resolve().parent.parent / "thumbnails" / "recording_thumbnail.png")
+DEFAULT_ACD_BUMPER_URL = "https://github.com/ethereum/pm/releases/download/acd-video-bumper-v1/ev.mp4"
+RAW_ZOOM_RECORDING_MODE = "raw_zoom_recording"
+COMPOSED_ZOOM_RECORDING_MODE = "composed_zoom_recording"
 
 def get_authenticated_service():
     # Initialize credentials from environment variables
@@ -276,6 +280,95 @@ def download_zoom_recording(meeting_id, min_duration_minutes=15, target_start_ti
         os.unlink(temp_file.name)  # Clean up failed download
         return None
 
+
+def download_bumper_from_url(url):
+    """Download the configured ACD bumper to a temporary local file."""
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
+    try:
+        with requests.get(url, stream=True, timeout=60) as response:
+            if response.status_code != 200:
+                raise RuntimeError(f"Failed to download bumper: HTTP {response.status_code}")
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                if chunk:
+                    temp_file.write(chunk)
+    finally:
+        temp_file.close()
+
+    path = Path(temp_file.name)
+    print(f"[SUCCESS] Downloaded bumper to: {path} ({path.stat().st_size / 1024 / 1024:.1f} MiB)")
+    return path
+
+
+def resolve_bumper_path():
+    """Resolve the bumper MP4 path for composed recording uploads."""
+    configured_path = os.environ.get("ACD_BUMPER_PATH")
+    if configured_path:
+        path = Path(configured_path)
+        if not path.exists():
+            raise FileNotFoundError(f"ACD_BUMPER_PATH does not exist: {path}")
+        return path, False
+
+    bumper_url = os.environ.get("ACD_BUMPER_URL") or DEFAULT_ACD_BUMPER_URL
+    return download_bumper_from_url(bumper_url), True
+
+
+def prepare_upload_video(
+    call_series_key,
+    recording_info,
+    meeting_id,
+    min_duration_minutes=15,
+    target_start_time=None,
+    tolerance_minutes=120,
+):
+    """Prepare the MP4 that should be uploaded for one call occurrence."""
+    mode = get_recording_publication_mode(call_series_key)
+    print(f"[INFO] Recording publication mode for {call_series_key}: {mode}")
+
+    if mode == RAW_ZOOM_RECORDING_MODE:
+        return download_zoom_recording(
+            meeting_id,
+            min_duration_minutes=min_duration_minutes,
+            target_start_time=target_start_time,
+            tolerance_minutes=tolerance_minutes,
+            recording_info=recording_info,
+        )
+
+    if mode == COMPOSED_ZOOM_RECORDING_MODE:
+        from scripts.compose_zoom_recording import compose_zoom_recording
+
+        bumper_path, cleanup_bumper = resolve_bumper_path()
+        output_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
+        output_file.close()
+        output_path = Path(output_file.name)
+        try:
+            composed_path = compose_zoom_recording(
+                recording_info=recording_info,
+                bumper_path=bumper_path,
+                output_path=output_path,
+                access_token=get_access_token(),
+            )
+            if not composed_path:
+                try:
+                    os.unlink(output_path)
+                except FileNotFoundError:
+                    pass
+                return None
+            return str(composed_path)
+        except Exception:
+            try:
+                os.unlink(output_path)
+            except FileNotFoundError:
+                pass
+            raise
+        finally:
+            if cleanup_bumper:
+                try:
+                    os.unlink(bumper_path)
+                except FileNotFoundError:
+                    pass
+
+    raise ValueError(f"Unsupported recording publication mode for {call_series_key}: {mode}")
+
 def upload_recording(meeting_id, occurrence_issue_number=None, error_collector=None, min_duration=15):
     """Uploads Zoom recording to YouTube for a specific occurrence.
 
@@ -393,12 +486,13 @@ def upload_recording(meeting_id, occurrence_issue_number=None, error_collector=N
         print(f"[WARN] Could not check recording duration for meeting {meeting_id}: {e}")
         # Continue with download attempt if we can't check duration
 
-    video_path = download_zoom_recording(
+    video_path = prepare_upload_video(
+        call_series_key,
+        recording_info,
         meeting_id,
         min_duration_minutes=min_duration,
         target_start_time=occurrence_start_time,
         tolerance_minutes=120,
-        recording_info=recording_info,
     )
     if not video_path:
         print(f"[SKIP] No MP4 recording available for meeting {meeting_id}")

--- a/.github/ACDbot/tests/unit/test_call_series_config.py
+++ b/.github/ACDbot/tests/unit/test_call_series_config.py
@@ -14,6 +14,7 @@ from modules.call_series_config import (
     get_autopilot_defaults,
     has_autopilot_support,
     get_default_autopilot_settings,
+    get_recording_publication_mode,
 )
 
 
@@ -241,6 +242,25 @@ class TestAutopilotConfig:
         assert defaults["duration"] == 90
         assert defaults["occurrence_rate"] == "bi-weekly"
         assert defaults["need_youtube_streams"] is True
+
+    def test_get_autopilot_defaults_for_acdt_disables_livestreams(self):
+        """Test that ACDT no longer creates scheduled livestreams."""
+        defaults = get_autopilot_defaults("acdt")
+
+        assert defaults is not None
+        assert defaults["duration"] == 60
+        assert defaults["occurrence_rate"] == "weekly"
+        assert defaults["need_youtube_streams"] is False
+
+    def test_get_recording_publication_mode_defaults_to_raw_zoom_recording(self):
+        """Test that series upload raw Zoom recordings unless configured otherwise."""
+        assert get_recording_publication_mode("acde") == "raw_zoom_recording"
+        assert get_recording_publication_mode("acdc") == "raw_zoom_recording"
+        assert get_recording_publication_mode("nonexistent") == "raw_zoom_recording"
+
+    def test_get_recording_publication_mode_for_acdt(self):
+        """Test that ACDT uses the composed recording upload path."""
+        assert get_recording_publication_mode("acdt") == "composed_zoom_recording"
 
     def test_get_autopilot_defaults_for_one_off(self):
         """Test that one-off calls have no autopilot defaults."""

--- a/.github/ACDbot/tests/unit/test_call_series_config.py
+++ b/.github/ACDbot/tests/unit/test_call_series_config.py
@@ -243,14 +243,14 @@ class TestAutopilotConfig:
         assert defaults["occurrence_rate"] == "bi-weekly"
         assert defaults["need_youtube_streams"] is True
 
-    def test_get_autopilot_defaults_for_acdt_disables_livestreams(self):
-        """Test that ACDT no longer creates scheduled livestreams."""
+    def test_get_autopilot_defaults_for_acdt_keeps_livestreams_enabled(self):
+        """Test that ACDT stays on scheduled livestreams during test mode."""
         defaults = get_autopilot_defaults("acdt")
 
         assert defaults is not None
         assert defaults["duration"] == 60
         assert defaults["occurrence_rate"] == "weekly"
-        assert defaults["need_youtube_streams"] is False
+        assert defaults["need_youtube_streams"] is True
 
     def test_get_recording_publication_mode_defaults_to_raw_zoom_recording(self):
         """Test that series upload raw Zoom recordings unless configured otherwise."""
@@ -258,9 +258,9 @@ class TestAutopilotConfig:
         assert get_recording_publication_mode("acdc") == "raw_zoom_recording"
         assert get_recording_publication_mode("nonexistent") == "raw_zoom_recording"
 
-    def test_get_recording_publication_mode_for_acdt(self):
-        """Test that ACDT uses the composed recording upload path."""
-        assert get_recording_publication_mode("acdt") == "composed_zoom_recording"
+    def test_get_recording_publication_mode_for_acdt_defaults_to_raw_during_test_mode(self):
+        """Test that ACDT does not use composed uploads until the follow-up activation."""
+        assert get_recording_publication_mode("acdt") == "raw_zoom_recording"
 
     def test_get_autopilot_defaults_for_one_off(self):
         """Test that one-off calls have no autopilot defaults."""

--- a/.github/ACDbot/tests/unit/test_compose_zoom_recording.py
+++ b/.github/ACDbot/tests/unit/test_compose_zoom_recording.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import datetime, timezone
 
 import pytest
 
@@ -6,9 +7,83 @@ from scripts.compose_zoom_recording import (
     ZoomTrimWindow,
     build_ffmpeg_command,
     extract_peak_level_db,
+    select_recording_target,
     select_recording_files,
     transcript_speech_window,
 )
+
+
+def test_select_recording_target_returns_latest_recent_past_occurrence():
+    mapping = {
+        "acdt": {
+            "meeting_id": "88479308162",
+            "occurrences": [
+                {
+                    "occurrence_number": 80,
+                    "issue_number": 2049,
+                    "issue_title": "ACDT #80",
+                    "start_time": "2026-05-18T14:00:00Z",
+                    "duration": 60,
+                },
+                {
+                    "occurrence_number": 81,
+                    "issue_number": 2085,
+                    "issue_title": "ACDT #81",
+                    "start_time": "2026-06-01T14:00:00Z",
+                    "duration": 60,
+                },
+                {
+                    "occurrence_number": 82,
+                    "issue_number": 2090,
+                    "issue_title": "ACDT #82",
+                    "start_time": "2026-06-08T14:00:00Z",
+                    "duration": 60,
+                },
+            ],
+        }
+    }
+
+    target = select_recording_target(
+        mapping,
+        "acdt",
+        max_age_days=3,
+        now=datetime(2026, 6, 1, 16, tzinfo=timezone.utc),
+    )
+
+    assert target is not None
+    assert target.number == 81
+    assert target.issue_number == 2085
+    assert target.meeting_id == "88479308162"
+
+
+def test_select_recording_target_can_force_public_number():
+    mapping = {
+        "acdt": {
+            "meeting_id": "88479308162",
+            "occurrences": [
+                {
+                    "occurrence_number": 80,
+                    "issue_number": 2049,
+                    "issue_title": "ACDT #80",
+                    "start_time": "2026-05-18T14:00:00Z",
+                    "duration": 60,
+                },
+                {
+                    "occurrence_number": 81,
+                    "issue_number": 2085,
+                    "issue_title": "ACDT #81",
+                    "start_time": "2026-06-01T14:00:00Z",
+                    "duration": 60,
+                },
+            ],
+        }
+    }
+
+    target = select_recording_target(mapping, "acdt", number=80)
+
+    assert target is not None
+    assert target.number == 80
+    assert target.issue_number == 2049
 
 
 def test_build_ffmpeg_command_uses_first_and_last_45_seconds_of_bumper():

--- a/.github/ACDbot/tests/unit/test_compose_zoom_recording.py
+++ b/.github/ACDbot/tests/unit/test_compose_zoom_recording.py
@@ -1,0 +1,158 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.compose_zoom_recording import (
+    ZoomTrimWindow,
+    build_ffmpeg_command,
+    extract_peak_level_db,
+    select_recording_files,
+    transcript_speech_window,
+)
+
+
+def test_build_ffmpeg_command_uses_first_and_last_45_seconds_of_bumper():
+    command = build_ffmpeg_command(
+        Path("ev.mp4"),
+        Path("zoom.mp4"),
+        Path("out.mp4"),
+        bumper_duration=318.8,
+    )
+
+    command_text = " ".join(command)
+
+    assert command[:6] == ["ffmpeg", "-y", "-hide_banner", "-i", "ev.mp4", "-i"]
+    assert "trim=start=0:end=45.000000" in command_text
+    assert "[1:v]trim=start=0.000000" in command_text
+    assert "trim=start=273.800000:end=318.800000" in command_text
+    assert "concat=n=3:v=1:a=1" in command_text
+    assert "libx264" in command
+    assert "+faststart" in command
+
+
+def test_build_ffmpeg_command_rejects_short_bumper():
+    with pytest.raises(ValueError, match="Bumper must be at least 90 seconds"):
+        build_ffmpeg_command(
+            Path("ev.mp4"),
+            Path("zoom.mp4"),
+            Path("out.mp4"),
+            bumper_duration=80,
+        )
+
+
+def test_build_ffmpeg_command_uses_separate_zoom_audio_when_available():
+    command = build_ffmpeg_command(
+        Path("ev.mp4"),
+        Path("zoom.mp4"),
+        Path("out.mp4"),
+        bumper_duration=318.8,
+        zoom_audio_path=Path("zoom.m4a"),
+    )
+
+    command_text = " ".join(command)
+
+    assert command[:8] == ["ffmpeg", "-y", "-hide_banner", "-i", "ev.mp4", "-i", "zoom.mp4", "-i"]
+    assert "zoom.m4a" in command
+    assert "[2:a]atrim=start=0.000000,asetpts=PTS-STARTPTS" in command_text
+
+
+def test_build_ffmpeg_command_trims_zoom_segment_when_requested():
+    command = build_ffmpeg_command(
+        Path("ev.mp4"),
+        Path("zoom.mp4"),
+        Path("out.mp4"),
+        bumper_duration=318.8,
+        zoom_audio_path=Path("zoom.m4a"),
+        zoom_trim=ZoomTrimWindow(start_seconds=12.5, end_seconds=130.25),
+    )
+
+    command_text = " ".join(command)
+
+    assert "[1:v]trim=start=12.500000:end=130.250000" in command_text
+    assert "[2:a]atrim=start=12.500000:end=130.250000" in command_text
+
+
+def test_select_recording_files_prefers_required_caption_layout_and_largest_audio():
+    selected = select_recording_files(
+        {
+            "recording_files": [
+                {
+                    "file_type": "MP4",
+                    "recording_type": "shared_screen_with_speaker_view",
+                    "download_url": "https://example.com/screen-speaker.mp4",
+                    "file_size": 100_000_000,
+                },
+                {
+                    "file_type": "MP4",
+                    "recording_type": "shared_screen_with_speaker_view(CC)",
+                    "download_url": "https://example.com/screen-speaker-cc.mp4",
+                    "file_size": 10_000,
+                },
+                {
+                    "file_type": "M4A",
+                    "recording_type": "audio_only",
+                    "download_url": "https://example.com/small.m4a",
+                    "file_size": 1_000,
+                },
+                {
+                    "file_type": "M4A",
+                    "recording_type": "audio_only",
+                    "download_url": "https://example.com/audio.m4a",
+                    "file_size": 9_000_000,
+                },
+            ]
+        }
+    )
+
+    assert selected is not None
+    assert selected.video_file["download_url"] == "https://example.com/screen-speaker-cc.mp4"
+    assert selected.audio_file is not None
+    assert selected.audio_file["download_url"] == "https://example.com/audio.m4a"
+
+
+def test_select_recording_files_rejects_non_speaker_composite_layouts():
+    selected = select_recording_files(
+        {
+            "recording_files": [
+                {
+                    "file_type": "MP4",
+                    "recording_type": "speaker_view",
+                    "download_url": "https://example.com/speaker.mp4",
+                    "file_size": 100_000_000,
+                },
+                {
+                    "file_type": "MP4",
+                    "recording_type": "shared_screen",
+                    "download_url": "https://example.com/screen.mp4",
+                    "file_size": 9_000,
+                },
+            ]
+        }
+    )
+
+    assert selected is None
+
+
+def test_extract_peak_level_db_returns_loudest_finite_peak():
+    output = """
+    [Parsed_astats_0] Peak level dB: -inf
+    [Parsed_astats_0] Peak level dB: -42.10
+    [Parsed_astats_0] Peak level dB: -18.25
+    """
+
+    assert extract_peak_level_db(output) == -18.25
+
+
+def test_transcript_speech_window_uses_first_and_last_vtt_cues_with_padding():
+    transcript = """WEBVTT
+
+00:00:18.000 --> 00:00:20.000
+Speaker: hello
+
+00:15:00.000 --> 00:15:12.500
+Speaker: bye
+"""
+
+    window = transcript_speech_window(transcript, duration_seconds=1000, padding_seconds=10)
+
+    assert window == ZoomTrimWindow(start_seconds=8, end_seconds=922.5)

--- a/.github/ACDbot/tests/unit/test_upload_zoom_recording.py
+++ b/.github/ACDbot/tests/unit/test_upload_zoom_recording.py
@@ -95,3 +95,59 @@ def test_recording_type_matches_zoom_cc_suffix():
         "shared_screen_with_speaker_view(CC)",
         "shared_screen_with_speaker_view",
     )
+
+
+def test_prepare_upload_video_uses_raw_zoom_recording_mode(monkeypatch):
+    upload_zoom_recording = load_upload_module()
+    calls = []
+
+    monkeypatch.setattr(upload_zoom_recording, "get_recording_publication_mode", lambda _series: "raw_zoom_recording")
+
+    def fake_download_zoom_recording(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "/tmp/raw.mp4"
+
+    monkeypatch.setattr(upload_zoom_recording, "download_zoom_recording", fake_download_zoom_recording)
+
+    result = upload_zoom_recording.prepare_upload_video(
+        "acde",
+        {"recording_files": []},
+        "123",
+        min_duration_minutes=10,
+        target_start_time="2026-06-01T14:00:00Z",
+    )
+
+    assert result == "/tmp/raw.mp4"
+    assert calls[0][0][0] == "123"
+    assert calls[0][1]["recording_info"] == {"recording_files": []}
+
+
+def test_prepare_upload_video_uses_composed_zoom_recording_mode(monkeypatch, tmp_path):
+    upload_zoom_recording = load_upload_module()
+
+    bumper_path = tmp_path / "bumper.mp4"
+    bumper_path.write_bytes(b"bumper")
+    composed_path = tmp_path / "composed.mp4"
+
+    monkeypatch.setattr(upload_zoom_recording, "get_recording_publication_mode", lambda _series: "composed_zoom_recording")
+    monkeypatch.setattr(upload_zoom_recording, "resolve_bumper_path", lambda: (bumper_path, False))
+    monkeypatch.setattr(upload_zoom_recording, "get_access_token", lambda: "zoom-token")
+
+    from scripts import compose_zoom_recording
+
+    def fake_compose_zoom_recording(recording_info, bumper_path, output_path, access_token):
+        assert recording_info == {"recording_files": [{"file_type": "MP4"}]}
+        assert bumper_path == tmp_path / "bumper.mp4"
+        assert access_token == "zoom-token"
+        output_path.write_bytes(b"composed")
+        return composed_path
+
+    monkeypatch.setattr(compose_zoom_recording, "compose_zoom_recording", fake_compose_zoom_recording)
+
+    result = upload_zoom_recording.prepare_upload_video(
+        "acdt",
+        {"recording_files": [{"file_type": "MP4"}]},
+        "123",
+    )
+
+    assert result == str(composed_path)

--- a/.github/workflows/meeting-asset-pipeline.yml
+++ b/.github/workflows/meeting-asset-pipeline.yml
@@ -142,6 +142,46 @@ jobs:
           MATTERMOST_BOT_WEBHOOK_URL: ${{ secrets.MATTERMOST_BOT_WEBHOOK_URL }}
           ACD_BUMPER_URL: ${{ vars.ACD_BUMPER_URL || secrets.ACD_BUMPER_URL || 'https://github.com/ethereum/pm/releases/download/acd-video-bumper-v1/ev.mp4' }}
 
+      - name: Compose ACDT recording test artifact
+        if: env.INPUT_FORCE_SERIES == '' || env.INPUT_FORCE_SERIES == 'acdt'
+        continue-on-error: true
+        run: |
+          mkdir -p "${RUNNER_TEMP}/acdt-compose-test"
+          curl --fail --location --retry 3 --retry-delay 5 "$ACD_BUMPER_URL" --output "${RUNNER_TEMP}/acdt-compose-test/ev.mp4"
+          ffprobe -v error -show_entries format=duration,size -of json "${RUNNER_TEMP}/acdt-compose-test/ev.mp4"
+
+          args=(
+            --series acdt
+            --bumper "${RUNNER_TEMP}/acdt-compose-test/ev.mp4"
+            --output "${RUNNER_TEMP}/acdt-compose-test/acdt-composed-recording.mp4"
+            --metadata "${RUNNER_TEMP}/acdt-compose-test/metadata.json"
+            --min-duration "$INPUT_MIN_DURATION"
+            --max-age-days 3
+          )
+
+          if [ "$INPUT_FORCE_SERIES" = "acdt" ] && [ -n "$INPUT_FORCE_NUMBER" ]; then
+            args+=(--number "$INPUT_FORCE_NUMBER")
+          fi
+
+          uv run --project "${GITHUB_WORKSPACE}/.github/ACDbot" --locked \
+            "${GITHUB_WORKSPACE}/.github/ACDbot/scripts/compose_zoom_recording.py" "${args[@]}"
+        env:
+          ZOOM_CLIENT_ID: ${{ secrets.ZOOM_CLIENT_ID }}
+          ZOOM_CLIENT_SECRET: ${{ secrets.ZOOM_CLIENT_SECRET }}
+          ZOOM_REFRESH_TOKEN: ${{ secrets.ZOOM_REFRESH_TOKEN }}
+          ACD_BUMPER_URL: ${{ vars.ACD_BUMPER_URL || secrets.ACD_BUMPER_URL || 'https://github.com/ethereum/pm/releases/download/acd-video-bumper-v1/ev.mp4' }}
+
+      - name: Upload ACDT composed recording test artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: acdt-composed-recording-test
+          path: |
+            ${{ runner.temp }}/acdt-compose-test/acdt-composed-recording.mp4
+            ${{ runner.temp }}/acdt-compose-test/metadata.json
+          if-no-files-found: ignore
+          retention-days: 3
+
       - name: Run asset pipeline
         if: success()
         continue-on-error: true

--- a/.github/workflows/meeting-asset-pipeline.yml
+++ b/.github/workflows/meeting-asset-pipeline.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Set up ACDbot
         uses: ./.github/actions/setup-acdbot
 
+      - name: Install ffmpeg
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+
       - name: Resolve forced meeting
         if: env.INPUT_FORCE_SERIES != '' && env.INPUT_FORCE_NUMBER != ''
         run: |
@@ -135,6 +140,7 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ vars.TELEGRAM_CHAT_ID }}
           MATTERMOST_BOT_WEBHOOK_URL: ${{ secrets.MATTERMOST_BOT_WEBHOOK_URL }}
+          ACD_BUMPER_URL: ${{ vars.ACD_BUMPER_URL || secrets.ACD_BUMPER_URL || 'https://github.com/ethereum/pm/releases/download/acd-video-bumper-v1/ev.mp4' }}
 
       - name: Run asset pipeline
         if: success()


### PR DESCRIPTION
## Summary

- keeps ACDT on the normal scheduled livestream path for the near-term call
- adds composed recording generation with ffmpeg using the first and last 45 seconds of the configured bumper
- runs the composed ACDT path as a GitHub Actions test artifact only; it does not upload the composed video to YouTube, update PM mapping, or dispatch Forkcast
- leaves ACDE and ACDC on the existing livestream path

## Operational checklist

- [ ] Keep the existing ACDT scheduled livestream active in YouTube Studio for the normal run
- [ ] After the normal ACDT run, inspect the `acdt-composed-recording-test` GitHub Actions artifact
- [ ] Close the superseded video composition spike PR after this lands
- [ ] Follow up by removing the test-only wrapper and enabling composed upload plus the Forkcast sync companion

## Tests

- `uv run --project .github/ACDbot --locked pytest .github/ACDbot/tests/unit`
- `uv run --project .github/ACDbot --locked python -m py_compile .github/ACDbot/scripts/compose_zoom_recording.py .github/ACDbot/scripts/upload_zoom_recording.py .github/ACDbot/modules/call_series_config.py`
- parsed `.github/workflows/meeting-asset-pipeline.yml` with PyYAML
- `git diff --check`
