### PR TITLE
Activate composed ACDT recording uploads

### DIFF
--- a/.github/ACDbot/call_series_config.yml
+++ b/.github/ACDbot/call_series_config.yml
@@ -64,10 +64,11 @@ call_series:
     display_name: "All Core Devs - Testing"
     youtube_playlist_id: "PLJqWcTqh_zKFE51VgNZmgT5SGYTKnyY6Y"
     discord_webhook_env: "DISCORD_ACD_WEBHOOK"
+    recording_publication_mode: "composed_zoom_recording"
     autopilot_defaults:
       duration: 60
       occurrence_rate: "weekly"
-      need_youtube_streams: true
+      need_youtube_streams: false
       display_zoom_link_in_invite: true
       external_meeting_link: false
 

--- a/.github/ACDbot/meeting_topic_mapping.json
+++ b/.github/ACDbot/meeting_topic_mapping.json
@@ -2557,7 +2557,7 @@
         "issue_title": "All Core Devs - Testing (ACDT) #82, June 8, 2026",
         "start_time": "2026-06-08T14:00:00Z",
         "duration": 60,
-        "skip_youtube_upload": true,
+        "skip_youtube_upload": false,
         "skip_transcript_processing": false,
         "youtube_upload_processed": false,
         "transcript_processed": false,
@@ -2565,15 +2565,7 @@
         "transcript_attempt_count": 0,
         "telegram_message_id": null,
         "youtube_streams_posted_to_discourse": false,
-        "youtube_streams": [
-          {
-            "broadcast_id": "3cdJXCB_-Bk",
-            "stream_id": "6rYoXJ_3BbPyWx_GQDDRRQ1780405798906197",
-            "stream_url": "https://youtube.com/watch?v=3cdJXCB_-Bk",
-            "rtmp_url": "rtmp://a.rtmp.youtube.com/live2/0q4r-vt2v-cwpq-a1gj-2xfa",
-            "scheduled_time": "2026-06-08T14:00:00.000Z"
-          }
-        ],
+        "youtube_streams": null,
         "occurrence_number": 50,
         "discourse_topic_id": 28681
       }

--- a/.github/ACDbot/scripts/compose_zoom_recording.py
+++ b/.github/ACDbot/scripts/compose_zoom_recording.py
@@ -34,7 +34,14 @@ VTT_CUE_PATTERN = re.compile(
     r"(?P<start>\d{2}:\d{2}:\d{2}\.\d{3}|\d{2}:\d{2}\.\d{3})\s+-->\s+"
     r"(?P<end>\d{2}:\d{2}:\d{2}\.\d{3}|\d{2}:\d{2}\.\d{3})"
 )
-REQUIRED_VIDEO_LAYOUT = "shared_screen_with_speaker_view"
+PREFERRED_VIDEO_LAYOUT = "shared_screen_with_speaker_view"
+VIDEO_LAYOUT_PRIORITY = [
+    PREFERRED_VIDEO_LAYOUT,
+    "shared_screen_with_gallery_view",
+    "active_speaker",
+    "gallery_view",
+    "shared_screen",
+]
 DEFAULT_BUMPER_CLIP_SECONDS = 45.0
 ACDBOT_DIR = Path(__file__).resolve().parents[1]
 MAPPING_FILE_PATH = ACDBOT_DIR / "meeting_topic_mapping.json"
@@ -228,10 +235,15 @@ def normalize_recording_type(recording_type: str) -> str:
     return recording_type.removesuffix("(CC)")
 
 
-def required_video_rank(file_info: dict[str, Any]) -> tuple[int, int]:
+def video_layout_rank(file_info: dict[str, Any]) -> tuple[int, int, int]:
     recording_type = file_info.get("recording_type", "")
-    is_not_caption_variant = int(recording_type != f"{REQUIRED_VIDEO_LAYOUT}(CC)")
-    return is_not_caption_variant, -(file_info.get("file_size") or 0)
+    normalized_recording_type = normalize_recording_type(recording_type)
+    try:
+        layout_rank = VIDEO_LAYOUT_PRIORITY.index(normalized_recording_type)
+    except ValueError:
+        layout_rank = len(VIDEO_LAYOUT_PRIORITY)
+    is_not_caption_variant = int(not recording_type.endswith("(CC)"))
+    return layout_rank, is_not_caption_variant, -(file_info.get("file_size") or 0)
 
 
 def select_recording_files(recording_info: dict[str, Any]) -> SelectedRecordingFiles | None:
@@ -249,20 +261,26 @@ def select_recording_files(recording_info: dict[str, Any]) -> SelectedRecordingF
         )
         print(f"[INFO] Available Zoom MP4 layouts: {available}")
 
-    required_video_files = [
+    ranked_video_files = [
         file_info
         for file_info in video_files
-        if normalize_recording_type(file_info.get("recording_type", "")) == REQUIRED_VIDEO_LAYOUT
+        if normalize_recording_type(file_info.get("recording_type", "")) in VIDEO_LAYOUT_PRIORITY
     ]
-    video_file = min(required_video_files, key=required_video_rank) if required_video_files else None
+    video_file = min(ranked_video_files, key=video_layout_rank) if ranked_video_files else None
     if video_file is None:
-        print(f"[WARN] Recording had no required MP4 video layout: {REQUIRED_VIDEO_LAYOUT}")
+        print(f"[WARN] Recording had no supported MP4 video layout: {', '.join(VIDEO_LAYOUT_PRIORITY)}")
         return None
 
+    selected_layout = normalize_recording_type(video_file.get("recording_type", ""))
     print(
-        "[DEBUG] Selected required video layout: "
+        "[DEBUG] Selected Zoom video layout: "
         f"{video_file.get('recording_type', 'unknown')} size={video_file.get('file_size', 'unknown')}"
     )
+    if selected_layout != PREFERRED_VIDEO_LAYOUT:
+        print(
+            "[WARN] Preferred Zoom video layout was unavailable; "
+            f"using fallback layout: {video_file.get('recording_type', 'unknown')}"
+        )
 
     audio_candidates = [
         file_info
@@ -390,8 +408,8 @@ def compose_zoom_recording(
     selected_files = select_recording_files(recording_info)
     if not selected_files:
         raise RuntimeError(
-            "Zoom recording exists but does not include required video layout "
-            f"{REQUIRED_VIDEO_LAYOUT}. Check the host's Zoom cloud recording settings."
+            "Zoom recording exists but does not include a supported MP4 video layout. "
+            "Check the host's Zoom cloud recording settings."
         )
 
     zoom_path = download_zoom_file(selected_files.video_file, access_token, ".mp4")

--- a/.github/ACDbot/tests/unit/test_call_series_config.py
+++ b/.github/ACDbot/tests/unit/test_call_series_config.py
@@ -243,14 +243,14 @@ class TestAutopilotConfig:
         assert defaults["occurrence_rate"] == "bi-weekly"
         assert defaults["need_youtube_streams"] is True
 
-    def test_get_autopilot_defaults_for_acdt_keeps_livestreams_enabled(self):
-        """Test that ACDT stays on scheduled livestreams during test mode."""
+    def test_get_autopilot_defaults_for_acdt_uses_recorded_uploads(self):
+        """Test that ACDT does not create scheduled livestreams."""
         defaults = get_autopilot_defaults("acdt")
 
         assert defaults is not None
         assert defaults["duration"] == 60
         assert defaults["occurrence_rate"] == "weekly"
-        assert defaults["need_youtube_streams"] is True
+        assert defaults["need_youtube_streams"] is False
 
     def test_get_recording_publication_mode_defaults_to_raw_zoom_recording(self):
         """Test that series upload raw Zoom recordings unless configured otherwise."""
@@ -258,9 +258,9 @@ class TestAutopilotConfig:
         assert get_recording_publication_mode("acdc") == "raw_zoom_recording"
         assert get_recording_publication_mode("nonexistent") == "raw_zoom_recording"
 
-    def test_get_recording_publication_mode_for_acdt_defaults_to_raw_during_test_mode(self):
-        """Test that ACDT does not use composed uploads until the follow-up activation."""
-        assert get_recording_publication_mode("acdt") == "raw_zoom_recording"
+    def test_get_recording_publication_mode_for_acdt_uses_composed_uploads(self):
+        """Test that ACDT uploads the composed bumper plus Zoom recording."""
+        assert get_recording_publication_mode("acdt") == "composed_zoom_recording"
 
     def test_get_autopilot_defaults_for_one_off(self):
         """Test that one-off calls have no autopilot defaults."""

--- a/.github/ACDbot/tests/unit/test_compose_zoom_recording.py
+++ b/.github/ACDbot/tests/unit/test_compose_zoom_recording.py
@@ -185,21 +185,39 @@ def test_select_recording_files_prefers_required_caption_layout_and_largest_audi
     assert selected.audio_file["download_url"] == "https://example.com/audio.m4a"
 
 
-def test_select_recording_files_rejects_non_speaker_composite_layouts():
+def test_select_recording_files_falls_back_to_active_speaker_without_shared_screen():
     selected = select_recording_files(
         {
             "recording_files": [
                 {
                     "file_type": "MP4",
-                    "recording_type": "speaker_view",
-                    "download_url": "https://example.com/speaker.mp4",
+                    "recording_type": "active_speaker",
+                    "download_url": "https://example.com/active-speaker.mp4",
                     "file_size": 100_000_000,
                 },
                 {
                     "file_type": "MP4",
-                    "recording_type": "shared_screen",
-                    "download_url": "https://example.com/screen.mp4",
+                    "recording_type": "gallery_view",
+                    "download_url": "https://example.com/gallery.mp4",
                     "file_size": 9_000,
+                },
+            ]
+        }
+    )
+
+    assert selected is not None
+    assert selected.video_file["download_url"] == "https://example.com/active-speaker.mp4"
+
+
+def test_select_recording_files_rejects_unknown_video_layouts():
+    selected = select_recording_files(
+        {
+            "recording_files": [
+                {
+                    "file_type": "MP4",
+                    "recording_type": "unknown_layout",
+                    "download_url": "https://example.com/unknown.mp4",
+                    "file_size": 100_000_000,
                 },
             ]
         }

--- a/.github/workflows/meeting-asset-pipeline.yml
+++ b/.github/workflows/meeting-asset-pipeline.yml
@@ -142,46 +142,6 @@ jobs:
           MATTERMOST_BOT_WEBHOOK_URL: ${{ secrets.MATTERMOST_BOT_WEBHOOK_URL }}
           ACD_BUMPER_URL: ${{ vars.ACD_BUMPER_URL || secrets.ACD_BUMPER_URL || 'https://github.com/ethereum/pm/releases/download/acd-video-bumper-v1/ev.mp4' }}
 
-      - name: Compose ACDT recording test artifact
-        if: env.INPUT_FORCE_SERIES == '' || env.INPUT_FORCE_SERIES == 'acdt'
-        continue-on-error: true
-        run: |
-          mkdir -p "${RUNNER_TEMP}/acdt-compose-test"
-          curl --fail --location --retry 3 --retry-delay 5 "$ACD_BUMPER_URL" --output "${RUNNER_TEMP}/acdt-compose-test/ev.mp4"
-          ffprobe -v error -show_entries format=duration,size -of json "${RUNNER_TEMP}/acdt-compose-test/ev.mp4"
-
-          args=(
-            --series acdt
-            --bumper "${RUNNER_TEMP}/acdt-compose-test/ev.mp4"
-            --output "${RUNNER_TEMP}/acdt-compose-test/acdt-composed-recording.mp4"
-            --metadata "${RUNNER_TEMP}/acdt-compose-test/metadata.json"
-            --min-duration "$INPUT_MIN_DURATION"
-            --max-age-days 3
-          )
-
-          if [ "$INPUT_FORCE_SERIES" = "acdt" ] && [ -n "$INPUT_FORCE_NUMBER" ]; then
-            args+=(--number "$INPUT_FORCE_NUMBER")
-          fi
-
-          uv run --project "${GITHUB_WORKSPACE}/.github/ACDbot" --locked \
-            "${GITHUB_WORKSPACE}/.github/ACDbot/scripts/compose_zoom_recording.py" "${args[@]}"
-        env:
-          ZOOM_CLIENT_ID: ${{ secrets.ZOOM_CLIENT_ID }}
-          ZOOM_CLIENT_SECRET: ${{ secrets.ZOOM_CLIENT_SECRET }}
-          ZOOM_REFRESH_TOKEN: ${{ secrets.ZOOM_REFRESH_TOKEN }}
-          ACD_BUMPER_URL: ${{ vars.ACD_BUMPER_URL || secrets.ACD_BUMPER_URL || 'https://github.com/ethereum/pm/releases/download/acd-video-bumper-v1/ev.mp4' }}
-
-      - name: Upload ACDT composed recording test artifact
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: acdt-composed-recording-test
-          path: |
-            ${{ runner.temp }}/acdt-compose-test/acdt-composed-recording.mp4
-            ${{ runner.temp }}/acdt-compose-test/metadata.json
-          if-no-files-found: ignore
-          retention-days: 3
-
       - name: Run asset pipeline
         if: success()
         continue-on-error: true


### PR DESCRIPTION
## Summary

- switches ACDT from scheduled livestream defaults to composed Zoom recording uploads
- makes the June 8, 2026 ACDT 82 occurrence eligible for post-call upload by clearing the scheduled stream metadata and `skip_youtube_upload`
- removes the temporary ACDT composed-recording artifact step now that the normal upload path can compose the video
- lets composed uploads prefer Zoom's shared-screen-with-speaker layout, then fall back to other Zoom MP4 layouts when the preferred layout was not generated

## Context

This follows the test-only ACDT recording pipeline that landed in PM. The June 1 ACDT test did not produce `shared_screen_with_speaker_view`; both Zoom UI and a fresh workflow probe showed the recording only had `active_speaker` / Speaker view. That is expected when nobody shares screen during the call: Zoom cannot generate a shared-screen layout if there is no shared screen content.

The composer now keeps the preferred layout first, while still producing a composed upload from the best available Zoom MP4 when the preferred layout is absent.

## Validation

- `uv run --project .github/ACDbot --locked pytest .github/ACDbot/tests/unit/test_call_series_config.py .github/ACDbot/tests/unit/test_upload_zoom_recording.py .github/ACDbot/tests/unit/test_compose_zoom_recording.py`
- `uv run --project .github/ACDbot --locked python -m py_compile .github/ACDbot/scripts/compose_zoom_recording.py .github/ACDbot/scripts/upload_zoom_recording.py .github/ACDbot/modules/call_series_config.py`
- parsed `.github/ACDbot/meeting_topic_mapping.json`, `.github/workflows/meeting-asset-pipeline.yml`, and `.github/ACDbot/call_series_config.yml`
- `git diff --check`