### PR TITLE
publish composed recording sync metadata

### DIFF
--- a/.github/ACDbot/scripts/asset_pipeline/composed_recording_sync.py
+++ b/.github/ACDbot/scripts/asset_pipeline/composed_recording_sync.py
@@ -1,0 +1,85 @@
+"""Pure timing helpers for composed Zoom recording sync."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+
+VTT_CUE_PATTERN = re.compile(
+    r"(?P<start>\d{2}:\d{2}:\d{2}\.\d{3}|\d{2}:\d{2}\.\d{3})\s+-->\s+"
+    r"(?P<end>\d{2}:\d{2}:\d{2}\.\d{3}|\d{2}:\d{2}\.\d{3})"
+)
+DEFAULT_BUMPER_CLIP_SECONDS = 45.0
+
+
+@dataclass(frozen=True)
+class ZoomTrimWindow:
+    start_seconds: float
+    end_seconds: float | None
+
+
+def parse_vtt_timestamp(value: str) -> float:
+    parts = value.split(":")
+    if len(parts) == 2:
+        minutes, seconds = parts
+        return int(minutes) * 60 + float(seconds)
+    if len(parts) == 3:
+        hours, minutes, seconds = parts
+        return int(hours) * 3600 + int(minutes) * 60 + float(seconds)
+    raise ValueError(f"Unsupported VTT timestamp: {value}")
+
+
+def transcript_cue_times(transcript_text: str) -> list[tuple[float, float]]:
+    return [
+        (parse_vtt_timestamp(match.group("start")), parse_vtt_timestamp(match.group("end")))
+        for match in VTT_CUE_PATTERN.finditer(transcript_text)
+    ]
+
+
+def transcript_speech_window(
+    transcript_text: str,
+    duration_seconds: float,
+    padding_seconds: float = 10,
+) -> ZoomTrimWindow | None:
+    cue_times = transcript_cue_times(transcript_text)
+    if not cue_times:
+        return None
+
+    first_start = min(start for start, _ in cue_times)
+    last_end = max(end for _, end in cue_times)
+    start_seconds = max(0, first_start - padding_seconds)
+    end_seconds = min(duration_seconds, last_end + padding_seconds)
+    if end_seconds <= start_seconds:
+        return None
+    return ZoomTrimWindow(start_seconds=start_seconds, end_seconds=end_seconds)
+
+
+def format_sync_timestamp(seconds: float) -> str:
+    whole_seconds = max(0, math.floor(seconds))
+    hours = whole_seconds // 3600
+    minutes = (whole_seconds % 3600) // 60
+    remaining_seconds = whole_seconds % 60
+    return f"{hours:02d}:{minutes:02d}:{remaining_seconds:02d}"
+
+
+def composed_recording_sync_from_transcript(
+    transcript_text: str,
+    duration_seconds: float = math.inf,
+    bumper_clip_seconds: float = DEFAULT_BUMPER_CLIP_SECONDS,
+) -> dict[str, str] | None:
+    cue_times = transcript_cue_times(transcript_text)
+    if not cue_times:
+        return None
+
+    trim_window = transcript_speech_window(transcript_text, duration_seconds=duration_seconds)
+    if not trim_window:
+        return None
+
+    first_start = min(start for start, _ in cue_times)
+    transcript_start_seconds = math.floor(first_start)
+    video_transcript_delta_seconds = round(bumper_clip_seconds - trim_window.start_seconds)
+    return {
+        "transcriptStartTime": format_sync_timestamp(transcript_start_seconds),
+        "videoStartTime": format_sync_timestamp(transcript_start_seconds + video_transcript_delta_seconds),
+    }

--- a/.github/ACDbot/scripts/asset_pipeline/generate_manifest.py
+++ b/.github/ACDbot/scripts/asset_pipeline/generate_manifest.py
@@ -11,6 +11,7 @@ import re
 from pathlib import Path
 
 import yaml
+from composed_recording_sync import composed_recording_sync_from_transcript
 from meeting_identity import get_occurrence_call_number
 
 SCRIPT_DIR = Path(__file__).parent
@@ -109,6 +110,26 @@ def get_call_resources(call_dir: Path) -> dict[str, str]:
     return resources
 
 
+def get_composed_recording_sync(
+    series_config: dict,
+    occurrence: dict | None,
+    call_dir: Path,
+    resources: dict[str, str],
+) -> dict[str, str] | None:
+    if series_config.get("recording_publication_mode") != "composed_zoom_recording":
+        return None
+    if not occurrence or not occurrence.get("youtube_video_id"):
+        return None
+
+    transcript_filename = resources.get("transcript_corrected") or resources.get("transcript")
+    if not transcript_filename:
+        return None
+
+    transcript_path = call_dir / transcript_filename
+    transcript_text = transcript_path.read_text(encoding="utf-8", errors="replace")
+    return composed_recording_sync_from_transcript(transcript_text)
+
+
 def generate_manifest() -> dict:
     """Generate the complete manifest."""
     call_series_config = load_call_series_config()
@@ -171,6 +192,10 @@ def generate_manifest() -> dict:
                 video_url = get_youtube_video_url(occurrence)
                 if video_url:
                     call_entry["videoUrl"] = video_url
+
+            sync = get_composed_recording_sync(series_config, occurrence, call_dir, resources)
+            if sync:
+                call_entry["sync"] = sync
 
             calls.append(call_entry)
 

--- a/.github/ACDbot/scripts/compose_zoom_recording.py
+++ b/.github/ACDbot/scripts/compose_zoom_recording.py
@@ -26,14 +26,16 @@ from typing import Any
 
 import requests
 
+from scripts.asset_pipeline.composed_recording_sync import (
+    DEFAULT_BUMPER_CLIP_SECONDS,
+    ZoomTrimWindow,
+    composed_recording_sync_from_transcript,
+    transcript_speech_window,
+)
 from scripts.asset_pipeline.meeting_identity import get_occurrence_call_number
 
 
 PEAK_LEVEL_PATTERN = re.compile(r"Peak level dB:\s+(-inf|[-0-9.]+)")
-VTT_CUE_PATTERN = re.compile(
-    r"(?P<start>\d{2}:\d{2}:\d{2}\.\d{3}|\d{2}:\d{2}\.\d{3})\s+-->\s+"
-    r"(?P<end>\d{2}:\d{2}:\d{2}\.\d{3}|\d{2}:\d{2}\.\d{3})"
-)
 # Prefer speaker-with-share because it keeps shared content plus speaker context
 # while producing smaller files than gallery-with-share. Zoom gallery tiles active
 # camera feeds, not camera-off participants' profile icons.
@@ -45,7 +47,6 @@ VIDEO_LAYOUT_PRIORITY = [
     "gallery_view",
     "shared_screen",
 ]
-DEFAULT_BUMPER_CLIP_SECONDS = 45.0
 ACDBOT_DIR = Path(__file__).resolve().parents[1]
 MAPPING_FILE_PATH = ACDBOT_DIR / "meeting_topic_mapping.json"
 
@@ -66,12 +67,6 @@ class SelectedRecordingFiles:
     video_file: dict[str, Any]
     audio_file: dict[str, Any] | None
     transcript_file: dict[str, Any] | None
-
-
-@dataclass(frozen=True)
-class ZoomTrimWindow:
-    start_seconds: float
-    end_seconds: float | None
 
 
 def parse_utc_timestamp(value: str | None) -> datetime | None:
@@ -316,38 +311,6 @@ def select_recording_files(recording_info: dict[str, Any]) -> SelectedRecordingF
         print("[WARN] No Zoom transcript found; dead-air trimming will be skipped")
 
     return SelectedRecordingFiles(video_file=video_file, audio_file=audio_file, transcript_file=transcript_file)
-
-
-def parse_vtt_timestamp(value: str) -> float:
-    parts = value.split(":")
-    if len(parts) == 2:
-        minutes, seconds = parts
-        return int(minutes) * 60 + float(seconds)
-    if len(parts) == 3:
-        hours, minutes, seconds = parts
-        return int(hours) * 3600 + int(minutes) * 60 + float(seconds)
-    raise ValueError(f"Unsupported VTT timestamp: {value}")
-
-
-def transcript_speech_window(
-    transcript_text: str,
-    duration_seconds: float,
-    padding_seconds: float = 10,
-) -> ZoomTrimWindow | None:
-    cue_times = [
-        (parse_vtt_timestamp(match.group("start")), parse_vtt_timestamp(match.group("end")))
-        for match in VTT_CUE_PATTERN.finditer(transcript_text)
-    ]
-    if not cue_times:
-        return None
-
-    first_start = min(start for start, _ in cue_times)
-    last_end = max(end for _, end in cue_times)
-    start_seconds = max(0, first_start - padding_seconds)
-    end_seconds = min(duration_seconds, last_end + padding_seconds)
-    if end_seconds <= start_seconds:
-        return None
-    return ZoomTrimWindow(start_seconds=start_seconds, end_seconds=end_seconds)
 
 
 def download_zoom_file(file_info: dict[str, Any], access_token: str, suffix: str) -> Path:

--- a/.github/ACDbot/tests/unit/test_asset_pipeline_identity.py
+++ b/.github/ACDbot/tests/unit/test_asset_pipeline_identity.py
@@ -526,3 +526,77 @@ call_series:
         match="artifact directory has no mapped occurrence: sample/2026-05-20_040",
     ):
         generate_manifest.generate_manifest()
+
+
+def test_manifest_includes_sync_only_for_composed_recording_uploads(tmp_path, monkeypatch):
+    generate_manifest = load_asset_pipeline_module("generate_manifest")
+
+    artifacts_dir = tmp_path / "artifacts"
+    upload_call_dir = artifacts_dir / "acdt" / "2026-06-08_082"
+    stream_call_dir = artifacts_dir / "acdt" / "2026-06-01_081"
+    upload_call_dir.mkdir(parents=True)
+    stream_call_dir.mkdir(parents=True)
+    transcript_text = """WEBVTT
+
+00:00:43.940 --> 00:00:45.659
+Justin: Good morning.
+"""
+    (upload_call_dir / "transcript.vtt").write_text(transcript_text, encoding="utf-8")
+    (stream_call_dir / "transcript.vtt").write_text(transcript_text, encoding="utf-8")
+
+    config_path = tmp_path / "call_series_config.yml"
+    config_path.write_text(
+        """
+call_series:
+  acdt:
+    display_name: "All Core Devs - Testing"
+    youtube_playlist_id: "PLJqWcTqh_zKSample"
+    recording_publication_mode: "composed_zoom_recording"
+""",
+        encoding="utf-8",
+    )
+
+    mapping_path = tmp_path / "meeting_topic_mapping.json"
+    mapping_path.write_text(
+        json.dumps(
+            {
+                "acdt": {
+                    "occurrences": [
+                        {
+                            "issue_number": 2103,
+                            "issue_title": "All Core Devs - Testing (ACDT) #82, June 8, 2026",
+                            "start_time": "2026-06-08T14:00:00Z",
+                            "occurrence_number": 82,
+                            "youtube_video_id": "sampleVideoId",
+                        },
+                        {
+                            "issue_number": 2098,
+                            "issue_title": "All Core Devs - Testing (ACDT) #81, June 1, 2026",
+                            "start_time": "2026-06-01T14:00:00Z",
+                            "occurrence_number": 81,
+                            "youtube_streams": [
+                                {
+                                    "stream_url": "https://www.youtube.com/watch?v=streamVideoId",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(generate_manifest, "ARTIFACTS_DIR", artifacts_dir)
+    monkeypatch.setattr(generate_manifest, "CALL_SERIES_CONFIG", config_path)
+    monkeypatch.setattr(generate_manifest, "MAPPING_FILE", mapping_path)
+
+    manifest = generate_manifest.generate_manifest()
+
+    calls_by_number = {call["number"]: call for call in manifest["series"]["acdt"]["calls"]}
+    assert calls_by_number[82]["sync"] == {
+        "transcriptStartTime": "00:00:43",
+        "videoStartTime": "00:00:54",
+    }
+    assert "sync" not in calls_by_number[81]
+    assert calls_by_number[81]["videoUrl"] == "https://www.youtube.com/watch?v=streamVideoId"

--- a/.github/ACDbot/tests/unit/test_compose_zoom_recording.py
+++ b/.github/ACDbot/tests/unit/test_compose_zoom_recording.py
@@ -6,6 +6,7 @@ import pytest
 from scripts.compose_zoom_recording import (
     ZoomTrimWindow,
     build_ffmpeg_command,
+    composed_recording_sync_from_transcript,
     extract_peak_level_db,
     select_recording_target,
     select_recording_files,
@@ -249,3 +250,29 @@ Speaker: bye
     window = transcript_speech_window(transcript, duration_seconds=1000, padding_seconds=10)
 
     assert window == ZoomTrimWindow(start_seconds=8, end_seconds=922.5)
+
+
+def test_composed_recording_sync_uses_bumper_and_transcript_trim():
+    transcript = """WEBVTT
+
+00:00:43.940 --> 00:00:45.659
+Speaker: hello
+"""
+
+    assert composed_recording_sync_from_transcript(transcript) == {
+        "transcriptStartTime": "00:00:43",
+        "videoStartTime": "00:00:54",
+    }
+
+
+def test_composed_recording_sync_can_have_video_before_transcript():
+    transcript = """WEBVTT
+
+00:04:47.490 --> 00:04:50.980
+Speaker: started
+"""
+
+    assert composed_recording_sync_from_transcript(transcript) == {
+        "transcriptStartTime": "00:04:47",
+        "videoStartTime": "00:00:55",
+    }


### PR DESCRIPTION
## Summary

- add generated sync metadata for composed Zoom recording uploads to the ACDbot manifest
- compute the sync anchor from shared pure transcript cue/trim timing helpers used by the composer
- publish sync only for mapped occurrences with an uploaded YouTube video ID, so older livestream ACDT artifacts are not marked as composed uploads
- keep Forkcast-facing timing metadata producer-owned so downstream consumers do not hardcode PM composition constants

## Validation

- uv run --project .github/ACDbot pytest .github/ACDbot/tests/unit/test_compose_zoom_recording.py .github/ACDbot/tests/unit/test_asset_pipeline_identity.py -q
- uv run --project .github/ACDbot pytest .github/ACDbot/tests/unit -q
- workflow-style manifest dry run confirmed ACDT 82 includes sync and ACDT 81 does not
- asset-pipeline cwd manifest dry run under the ACDbot project context succeeds
