### PR TITLE
acdbot: fix ACDT 083 client/name transcript corruption

### DIFF
--- a/.github/ACDbot/artifacts/acdt/2026-06-15_083/transcript_corrected.vtt
+++ b/.github/ACDbot/artifacts/acdt/2026-06-15_083/transcript_corrected.vtt
@@ -522,7 +522,7 @@ Potuz: We should phrase the discussion on whether or not we want this design or 
 
 131
 00:24:08.420 --> 00:24:16.829
-Potuz: It's false that we would need more time to implement the mitigations. The mitigations took less than a couple of days, Terence, to implement on PRISM.
+Potuz: It's false that we would need more time to implement the mitigations. The mitigations took less than a couple of days, Terence, to implement on Prysm.
 
 132
 00:24:17.070 --> 00:24:31.879
@@ -530,7 +530,7 @@ Potuz: So, it's a reality. We are going to delay the fork, because it needs coor
 
 133
 00:24:35.810 --> 00:24:39.910
-dan (danceratopz): Thanks a lot, Potus, for the perspective. Yeah.
+dan (danceratopz): Thanks a lot, Potuz, for the perspective. Yeah.
 
 134
 00:24:40.100 --> 00:24:42.120
@@ -622,7 +622,7 @@ dan (danceratopz): Otherwise, yeah, please put your thinking caps on and comment
 
 156
 00:27:23.130 --> 00:27:25.829
-dan (danceratopz): what we… what we need to do? Potus?
+dan (danceratopz): what we… what we need to do? Potuz?
 
 157
 00:27:26.790 --> 00:27:41.660
@@ -638,7 +638,7 @@ Potuz: So, DCIP is not preventing a cache that we need to handle at the fork. Yo
 
 160
 00:28:06.060 --> 00:28:07.830
-dan (danceratopz): Thank you, Potuz Dragon.
+dan (danceratopz): Thank you, Potuz Dragan.
 
 161
 00:28:09.040 --> 00:28:14.640
@@ -742,15 +742,15 @@ Potuz: And even at today's block sizes. And it's not what we're going to be broa
 
 186
 00:30:51.630 --> 00:31:07.719
-Potuz: the same 2 seconds for propagation plus execution, and on top of that, we're going to be broadcasting a block that is not 90% smaller, it's going to be twice as large as today. So I think it's just crazy to try to ship any gas limit now without EPBS.
+Potuz: the same 2 seconds for propagation plus execution, and on top of that, we're going to be broadcasting a block that is not 90% smaller, it's going to be twice as large as today. So I think it's just crazy to try to ship any gas limit now without ePBS.
 
 187
 00:31:13.130 --> 00:31:15.699
-dan (danceratopz): Thank you, Potus. Yeah, I mean…
+dan (danceratopz): Thank you, Potuz. Yeah, I mean…
 
 188
 00:31:15.910 --> 00:31:22.509
-dan (danceratopz): The other… on the other side, the other question that Terrence raises is, would this really delay EPBS by 3 months?
+dan (danceratopz): The other… on the other side, the other question that Terrence raises is, would this really delay ePBS by 3 months?
 
 189
 00:31:23.670 --> 00:31:25.770
@@ -794,7 +794,7 @@ Berlin People: Okay, but we're still targeting about 100 megas… 100 million ga
 
 199
 00:32:27.170 --> 00:32:38.169
-Potuz: That again, that again is without the propagation. So it's not about execution, it's execution plus propagation. We don't get the decoupling if we don't ship EPBS.
+Potuz: That again, that again is without the propagation. So it's not about execution, it's execution plus propagation. We don't get the decoupling if we don't ship ePBS.
 
 200
 00:32:38.500 --> 00:32:50.509
@@ -830,7 +830,7 @@ Dragan Rakita: We can… we can even be real, like, conservative and just leave 
 
 208
 00:33:23.610 --> 00:33:31.830
-Dragan Rakita: comes. But I don't see the point, basically, that we need… we need EPBS to increase the gas
+Dragan Rakita: comes. But I don't see the point, basically, that we need… we need ePBS to increase the gas
 
 209
 00:33:32.230 --> 00:33:37.660
@@ -926,7 +926,7 @@ Dragan Rakita: Just, like, information.
 
 232
 00:35:55.760 --> 00:35:58.779
-dan (danceratopz): Thanks, Barnabas. Thanks, Dragon.
+dan (danceratopz): Thanks, Barnabas. Thanks, Dragan.
 
 233
 00:35:59.870 --> 00:36:06.870

--- a/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
+++ b/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
@@ -215,6 +215,7 @@ error_patterns:
   - Stack2Deep: stack-too-deep
   - convection time: compaction time
   - Prism: Prysm
+  - PRISM: Prysm
   - state hearing: state tiering
   - LiDo: Lido
   - PECTRA: Pectra
@@ -222,6 +223,7 @@ error_patterns:
   - Portos: Potuz
   - Portis: Potuz
   - Potos: Potuz
+  - Potus: Potuz
   - Farnibus: Barnabas
   - strong map: strawmap
   - straw map: strawmap


### PR DESCRIPTION
Corrects remaining typos the asset pipeline missed in the ACDT 83 transcript, and teaches the vocab to catch them next time.

## Artifact fixes (`.github/ACDbot/artifacts/acdt/2026-06-15_083/transcript_corrected.vtt`)
- `PRISM` → `Prysm`
- `EPBS` → `ePBS`
- `Potus` → `Potuz`
- `Dragon` → `Dragan` (referring to Dragan Rakita)

## Vocab (`ethereum_vocab.yaml` error_patterns)
- Add `PRISM: Prysm` (only `prism`/`Prism` were covered)
- Add `Potus: Potuz` (consistent with existing `Potos`/`Portus` entries)

`Dragon → Dragan` is intentionally **not** added to the global vocab — "Dragon" is a common English word and a global find/replace would garble unrelated transcripts. `EPBS → ePBS` already exists in the vocab; this PR only fixes the artifact that predates it.