### PR TITLE
Propose Glamsterdam activation times for Sepolia and Hoodi

### DIFF
--- a/glamsterdam-pm.md
+++ b/glamsterdam-pm.md
@@ -5,7 +5,7 @@ Proposed activation times for the Glamsterdam (Gloas + Amsterdam) network upgrad
 | Network | Epoch | Start slot | Unix | UTC (+00:00) |
 |---------|-------|------------|------|--------------|
 | Sepolia | 353024 | 11296768 | 1791294816 | Tue, 06 Oct 2026, 13:53:36 |
-| Hoodi | 132352 | 4235264 | 1793036568 | Mon, 26 Oct 2026, 17:42:48 |
+| Hoodi | TBD | TBD | TBD | TBD |
 | Mainnet | TBD | TBD | TBD | TBD |
 
 - Sepolia: [configuration](https://github.com/eth-clients/sepolia)

--- a/glamsterdam-pm.md
+++ b/glamsterdam-pm.md
@@ -4,7 +4,7 @@ Proposed activation times for the Glamsterdam (Gloas + Amsterdam) network upgrad
 
 | Network | Epoch | Start slot | Unix | UTC (+00:00) |
 |---------|-------|------------|------|--------------|
-| Sepolia | 351232 | 11239424 | 1790606688 | Mon, 28 Sep 2026, 14:44:48 |
+| Sepolia | 353024 | 11296768 | 1791294816 | Tue, 06 Oct 2026, 13:53:36 |
 | Hoodi | 132352 | 4235264 | 1793036568 | Mon, 26 Oct 2026, 17:42:48 |
 | Mainnet | TBD | TBD | TBD | TBD |
 

--- a/glamsterdam-pm.md
+++ b/glamsterdam-pm.md
@@ -1,0 +1,13 @@
+# Glamsterdam Deployments
+
+Proposed activation times for the Glamsterdam (Gloas + Amsterdam) network upgrade on the public testnets.
+
+| Network | Epoch | Start slot | Unix | UTC (+00:00) |
+|---------|-------|------------|------|--------------|
+| Sepolia | 351232 | 11239424 | 1790606688 | Mon, 28 Sep 2026, 14:44:48 |
+| Hoodi | 132352 | 4235264 | 1793036568 | Mon, 26 Oct 2026, 17:42:48 |
+| Mainnet | TBD | TBD | TBD | TBD |
+
+- Sepolia: [configuration](https://github.com/eth-clients/sepolia)
+- Hoodi: [configuration](https://github.com/eth-clients/hoodi)
+- Mainnet: [configuration](https://github.com/eth-clients/mainnet)


### PR DESCRIPTION
Proposes activation times for Glamsterdam (Gloas + Amsterdam) on the public testnets, for client team review.

| Network | Epoch | Start slot | Unix | UTC |
|---|---|---|---|---|
| Sepolia | 353024 | 11296768 | 1791294816 | Tue, 06 Oct 2026, 13:53:36 |
| Hoodi | TBD | TBD | TBD | TBD |

The Sepolia value is epoch-aligned and consistent with the network's beacon genesis:
- Sepolia: 1655733600 + 11296768 * 12 = 1791294816

Hoodi and mainnet timings are left TBD. Once agreed, the timings get scheduled in eth-clients/sepolia and eth-clients/hoodi and filled into the EIP-7773 activation table.